### PR TITLE
Bump Ktfmt to 0.19

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,7 +5,7 @@ object Versions {
 
 object BuildPluginsVersion {
     const val DETEKT = "1.15.0"
-    const val KOTLIN = "1.3.72"
+    const val KOTLIN = "1.4.21"
     const val KTLINT = "9.4.1"
     const val VERSIONS_PLUGIN = "0.33.0"
 }

--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -1,17 +1,17 @@
 object Versions {
     const val AGP = "4.1.1"
-    const val COROUTINES = "1.3.9"
+    const val COROUTINES = "1.4.2"
     const val DIFF_UTIL = "4.9"
     const val JUPITER = "5.7.0"
     const val KTLINT = "0.39.0"
-    const val KTFMT = "0.18"
+    const val KTFMT = "0.19"
     const val TRUTH = "1.1"
 }
 
 object BuildPluginsVersion {
     const val BINARY_COMPATIBILITY_VALIDATOR = "0.2.4"
     const val DETEKT = "1.15.0"
-    const val KOTLIN = "1.3.72"
+    const val KOTLIN = "1.4.21"
     const val KTLINT = "9.4.1"
     const val PLUGIN_PUBLISH = "0.12.0"
     const val VERSIONS_PLUGIN = "0.33.0"

--- a/plugin-build/plugin/src/test/resources/jvmProject/build.gradle.kts
+++ b/plugin-build/plugin/src/test/resources/jvmProject/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.3.72"
+    kotlin("jvm") version "1.4.21"
     id("com.ncorti.ktfmt.gradle")
 }
 


### PR DESCRIPTION
## 🚀 Description
Bumping KtFmt to 0.19 https://github.com/facebookincubator/ktfmt/releases/tag/v0.19

## 📄 Motivation and Context
This introduces supports for Kotlin 1.4.x language feature.
All the Kotlin dependencies have been updated to match 1.4.x as well.

## 📦 Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)