### PR TITLE
Add googleStyle() to KtfmtExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+### Added
+
+- Added the `googleStyle()` function to the `ktfmt{}` extension to configure indents at `2`.
+
 ## Version 0.1.0 *(2020-12-22)*
 
 That's the first version of `ktfmt-gradle`

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -7,6 +7,7 @@ public abstract class com/ncorti/ktfmt/gradle/KtfmtExtension {
 	public final fun getDebuggingPrintOpsAfterFormatting ()Lorg/gradle/api/provider/Property;
 	public final fun getMaxWidth ()Lorg/gradle/api/provider/Property;
 	public final fun getRemoveUnusedImports ()Lorg/gradle/api/provider/Property;
+	public final fun googleStyle ()V
 }
 
 public abstract class com/ncorti/ktfmt/gradle/KtfmtPlugin : org/gradle/api/Plugin {

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
@@ -61,6 +61,15 @@ abstract class KtfmtExtension @Inject constructor(project: Project) {
         continuationIndent.set(4)
     }
 
+    /**
+     * Sets the Google style (equivalent to set blockIndent to 2 and continuationIndent to 2).
+     */
+    @Suppress("MagicNumber")
+    fun googleStyle() {
+        blockIndent.set(2)
+        continuationIndent.set(2)
+    }
+
     internal fun toBean(): FormattingOptionsBean = FormattingOptionsBean(
         maxWidth = maxWidth.get(),
         blockIndent = blockIndent.get(),

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
@@ -57,6 +57,16 @@ class KtfmtExtensionTest {
     }
 
     @Test
+    fun `googleStyle configures correctly`() {
+        val extension = object : KtfmtExtension(ProjectBuilder.builder().build()) {}
+
+        extension.googleStyle()
+
+        assertThat(extension.blockIndent.get()).isEqualTo(2)
+        assertThat(extension.continuationIndent.get()).isEqualTo(2)
+    }
+
+    @Test
     fun `toBean copies fields correctly`() {
         val extension = object : KtfmtExtension(ProjectBuilder.builder().build()) {}
 


### PR DESCRIPTION
## 🚀 Description
Aligning the KtfmtExtension with the new changes in `FormattingOptions` on ktfmt ends:
https://github.com/facebookincubator/ktfmt/blob/1bc396c0b95601b469ed30e82dcfa6a0e201927f/core/src/main/java/com/facebook/ktfmt/Formatter.kt#L43-L44

## 📄 Motivation and Context
You can now configure `googleFormat()` inside the `ktfmt{}` extension.

## 🧪 How Has This Been Tested?
Tests are attached

## 📦 Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)