### PR TITLE
Prepare release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file follows [Keepachangelog](https://keepachangelog.com/) format.
 Please add your entries according to this format.
 
-## Unreleased
+## Version 0.2.0 *(2020-12-24)*
 
 ### Added
 
@@ -11,7 +11,9 @@ Please add your entries according to this format.
 
 ### Dependencies Update
 
-- Kt
+- Ktfmt to 0.19
+- Kotlin to 1.4.21
+- kotlinx-coroutines to 1.4.2 
 
 ## Version 0.1.0 *(2020-12-22)*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Please add your entries according to this format.
 
 - Added the `googleStyle()` function to the `ktfmt{}` extension to configure indents at `2`.
 
+### Dependencies Update
+
+- Kt
+
 ## Version 0.1.0 *(2020-12-22)*
 
 That's the first version of `ktfmt-gradle`

--- a/plugin-build/buildSrc/src/main/java/Coordinates.kt
+++ b/plugin-build/buildSrc/src/main/java/Coordinates.kt
@@ -1,7 +1,7 @@
 object PluginCoordinates {
     const val ID = "com.ncorti.ktfmt.gradle"
     const val GROUP = "com.ncorti.ktfmt.gradle"
-    const val VERSION = "0.1.0"
+    const val VERSION = "0.2.0"
     const val IMPLEMENTATION_CLASS = "com.ncorti.ktfmt.gradle.KtfmtPlugin"
 }
 


### PR DESCRIPTION
## 🚀 Description
Releasing version `0.2.0` of the plugin

## 📄 Motivation and Context
This will unblock users that want to reformat Kotlin 1.4 code.

Please note that version `0.2.0` of the plugin will reformat Kotlin 1.4.x code only with **Gradle 6.8** (due to the embedded Kotlin version in Gradle).