### PR TITLE
Reformat the whole project with ktfmt-gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 plugins {
     kotlin("jvm") version BuildPluginsVersion.KOTLIN apply false
     id("io.gitlab.arturbosch.detekt") version BuildPluginsVersion.DETEKT
-    id("org.jlleitschuh.gradle.ktlint") version BuildPluginsVersion.KTLINT
     id("com.github.ben-manes.versions") version BuildPluginsVersion.VERSIONS_PLUGIN
 }
 
@@ -18,21 +17,6 @@ allprojects {
 subprojects {
     apply {
         plugin("io.gitlab.arturbosch.detekt")
-        plugin("org.jlleitschuh.gradle.ktlint")
-    }
-
-    ktlint {
-        debug.set(false)
-        version.set(Versions.KTLINT)
-        verbose.set(true)
-        android.set(false)
-        outputToConsole.set(true)
-        ignoreFailures.set(false)
-        enableExperimentalRules.set(true)
-        filter {
-            exclude("**/generated/**")
-            include("**/kotlin/**")
-        }
     }
 
     detekt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,8 +45,8 @@ tasks.register("clean", Delete::class.java) {
 tasks.register("reformatAll") {
     description = "Reformat all the Kotlin Code"
 
-    dependsOn("ktlintFormat")
-    dependsOn(gradle.includedBuild("plugin-build").task(":plugin:ktlintFormat"))
+    dependsOn(":example:ktfmtFormat")
+    dependsOn(gradle.includedBuild("plugin-build").task(":plugin:ktfmtFormat"))
 }
 
 tasks.register("preMerge") {

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     kotlin("jvm") version BuildPluginsVersion.KOTLIN apply false
     id("com.gradle.plugin-publish") version BuildPluginsVersion.PLUGIN_PUBLISH apply false
     id("io.gitlab.arturbosch.detekt") version BuildPluginsVersion.DETEKT
-    id("org.jlleitschuh.gradle.ktlint") version BuildPluginsVersion.KTLINT
+    id("com.ncorti.ktfmt.gradle") version BuildPluginsVersion.KTFMT
     id("com.github.ben-manes.versions") version BuildPluginsVersion.VERSIONS_PLUGIN
     id("binary-compatibility-validator") version BuildPluginsVersion.BINARY_COMPATIBILITY_VALIDATOR
 }
@@ -21,21 +21,11 @@ allprojects {
 
     apply {
         plugin("io.gitlab.arturbosch.detekt")
-        plugin("org.jlleitschuh.gradle.ktlint")
+        plugin("com.ncorti.ktfmt.gradle")
     }
 
-    ktlint {
-        debug.set(false)
-        version.set(Versions.KTLINT)
-        verbose.set(true)
-        android.set(false)
-        outputToConsole.set(true)
-        ignoreFailures.set(false)
-        enableExperimentalRules.set(true)
-        filter {
-            exclude("**/generated/**")
-            include("**/kotlin/**")
-        }
+    ktfmt {
+        dropboxStyle()
     }
 
     detekt {

--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -12,7 +12,7 @@ object BuildPluginsVersion {
     const val BINARY_COMPATIBILITY_VALIDATOR = "0.2.4"
     const val DETEKT = "1.15.0"
     const val KOTLIN = "1.4.21"
-    const val KTLINT = "9.4.1"
+    const val KTFMT = "0.1.0"
     const val PLUGIN_PUBLISH = "0.12.0"
     const val VERSIONS_PLUGIN = "0.33.0"
 }

--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,6 @@ object Versions {
     const val COROUTINES = "1.4.2"
     const val DIFF_UTIL = "4.9"
     const val JUPITER = "5.7.0"
-    const val KTLINT = "0.39.0"
     const val KTFMT = "0.19"
     const val TRUTH = "1.1"
 }
@@ -12,7 +11,7 @@ object BuildPluginsVersion {
     const val BINARY_COMPATIBILITY_VALIDATOR = "0.2.4"
     const val DETEKT = "1.15.0"
     const val KOTLIN = "1.4.21"
-    const val KTFMT = "0.1.0"
+    const val KTFMT = "0.2.0"
     const val PLUGIN_PUBLISH = "0.12.0"
     const val VERSIONS_PLUGIN = "0.33.0"
 }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
@@ -6,9 +6,7 @@ import java.io.Serializable
 
 internal data class FormattingOptionsBean(
 
-    /**
-     * ktfmt breaks lines longer than maxWidth.
-     */
+    /** ktfmt breaks lines longer than maxWidth. */
     val maxWidth: Int = DEFAULT_MAX_WIDTH,
 
     /**
@@ -43,13 +41,12 @@ internal data class FormattingOptionsBean(
      * newline) decisions
      */
     val debuggingPrintOpsAfterFormatting: Boolean = false
-
 ) : Serializable {
-    fun toFormattingOptions(): FormattingOptions = FormattingOptions(
-        maxWidth = maxWidth,
-        blockIndent = blockIndent,
-        continuationIndent = continuationIndent,
-        removeUnusedImports = removeUnusedImports,
-        debuggingPrintOpsAfterFormatting = debuggingPrintOpsAfterFormatting
-    )
+    fun toFormattingOptions(): FormattingOptions =
+        FormattingOptions(
+            maxWidth = maxWidth,
+            blockIndent = blockIndent,
+            continuationIndent = continuationIndent,
+            removeUnusedImports = removeUnusedImports,
+            debuggingPrintOpsAfterFormatting = debuggingPrintOpsAfterFormatting)
 }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
@@ -1,20 +1,16 @@
 package com.ncorti.ktfmt.gradle
 
+import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
-import javax.inject.Inject
 
-/**
- * Gradle Extension to help you configure ktfmt-gradle
- */
+/** Gradle Extension to help you configure ktfmt-gradle */
 @Suppress("UnnecessaryAbstractClass")
 abstract class KtfmtExtension @Inject constructor(project: Project) {
 
     private val objects = project.objects
 
-    /**
-     * ktfmt breaks lines longer than maxWidth. Default 100.
-     */
+    /** ktfmt breaks lines longer than maxWidth. Default 100. */
     val maxWidth: Property<Int> = objects.property(Int::class.java).convention(DEFAULT_MAX_WIDTH)
 
     /**
@@ -27,7 +23,8 @@ abstract class KtfmtExtension @Inject constructor(project: Project) {
      * }
      * ```
      */
-    val blockIndent: Property<Int> = objects.property(Int::class.java).convention(DEFAULT_BLOCK_INDENT)
+    val blockIndent: Property<Int> =
+        objects.property(Int::class.java).convention(DEFAULT_BLOCK_INDENT)
 
     /**
      * continuationIndent is the size of the indent used when a line is broken because it's too
@@ -39,7 +36,8 @@ abstract class KtfmtExtension @Inject constructor(project: Project) {
      *     1)
      * ```
      */
-    val continuationIndent: Property<Int> = objects.property(Int::class.java).convention(DEFAULT_CONTINUATION_INDENT)
+    val continuationIndent: Property<Int> =
+        objects.property(Int::class.java).convention(DEFAULT_CONTINUATION_INDENT)
 
     /** Whether ktfmt should remove imports that are not used. */
     val removeUnusedImports: Property<Boolean> =
@@ -52,31 +50,27 @@ abstract class KtfmtExtension @Inject constructor(project: Project) {
     val debuggingPrintOpsAfterFormatting: Property<Boolean> =
         objects.property(Boolean::class.java).convention(DEFAULT_DEBUGGING_PRINT_OPTS)
 
-    /**
-     * Enables --dropbox-style (equivalent to set blockIndent to 4 and continuationIndent to 4).
-     */
+    /** Enables --dropbox-style (equivalent to set blockIndent to 4 and continuationIndent to 4). */
     @Suppress("MagicNumber")
     fun dropboxStyle() {
         blockIndent.set(4)
         continuationIndent.set(4)
     }
 
-    /**
-     * Sets the Google style (equivalent to set blockIndent to 2 and continuationIndent to 2).
-     */
+    /** Sets the Google style (equivalent to set blockIndent to 2 and continuationIndent to 2). */
     @Suppress("MagicNumber")
     fun googleStyle() {
         blockIndent.set(2)
         continuationIndent.set(2)
     }
 
-    internal fun toBean(): FormattingOptionsBean = FormattingOptionsBean(
-        maxWidth = maxWidth.get(),
-        blockIndent = blockIndent.get(),
-        continuationIndent = continuationIndent.get(),
-        removeUnusedImports = removeUnusedImports.get(),
-        debuggingPrintOpsAfterFormatting = debuggingPrintOpsAfterFormatting.get()
-    )
+    internal fun toBean(): FormattingOptionsBean =
+        FormattingOptionsBean(
+            maxWidth = maxWidth.get(),
+            blockIndent = blockIndent.get(),
+            continuationIndent = continuationIndent.get(),
+            removeUnusedImports = removeUnusedImports.get(),
+            debuggingPrintOpsAfterFormatting = debuggingPrintOpsAfterFormatting.get())
 
     internal companion object {
         internal const val DEFAULT_MAX_WIDTH: Int = 100

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
@@ -12,6 +12,7 @@ import com.android.build.api.variant.VariantProperties
 import com.android.build.gradle.internal.api.DefaultAndroidSourceDirectorySet
 import com.ncorti.ktfmt.gradle.tasks.KtfmtCheckTask
 import com.ncorti.ktfmt.gradle.tasks.KtfmtFormatTask
+import java.util.concurrent.Callable
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -21,10 +22,11 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
-import java.util.concurrent.Callable
 
 private const val EXTENSION_NAME = "ktfmt"
+
 private const val TASK_NAME_FORMAT = "ktfmtFormat"
+
 private const val TASK_NAME_CHECK = "ktfmtCheck"
 
 /**
@@ -38,7 +40,8 @@ abstract class KtfmtPlugin : Plugin<Project> {
     private lateinit var topLevelCheck: TaskProvider<Task>
 
     override fun apply(project: Project) {
-        ktfmtExtension = project.extensions.create(EXTENSION_NAME, KtfmtExtension::class.java, project)
+        ktfmtExtension =
+            project.extensions.create(EXTENSION_NAME, KtfmtExtension::class.java, project)
 
         topLevelFormat = createTopLevelFormatTask(project)
         topLevelCheck = createTopLevelCheckTask(project)
@@ -46,28 +49,22 @@ abstract class KtfmtPlugin : Plugin<Project> {
         project.plugins.withId("kotlin") { applyKtfmt(project) }
         project.plugins.withId("kotlin-android") { applyKtfmtToAndroidProject(project) }
         project.plugins.withId("org.jetbrains.kotlin.js") { applyKtfmt(project) }
-        project.plugins.withId("org.jetbrains.kotlin.multiplatform") { applyKtfmtToMultiplatformProject(project) }
+        project.plugins.withId("org.jetbrains.kotlin.multiplatform") {
+            applyKtfmtToMultiplatformProject(project)
+        }
     }
 
     private fun applyKtfmt(project: Project) {
         val extension = project.extensions.getByType(KotlinProjectExtension::class.java)
         extension.sourceSets.all {
-            createTasksForSourceSet(
-                project,
-                it.name,
-                it.kotlin.sourceDirectories
-            )
+            createTasksForSourceSet(project, it.name, it.kotlin.sourceDirectories)
         }
     }
 
     private fun applyKtfmtToMultiplatformProject(project: Project) {
         val extension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
         extension.sourceSets.all {
-            createTasksForSourceSet(
-                project,
-                it.name,
-                it.kotlin.sourceDirectories
-            )
+            createTasksForSourceSet(project, it.name, it.kotlin.sourceDirectories)
         }
 
         extension.targets.all { kotlinTarget ->
@@ -100,25 +97,18 @@ abstract class KtfmtPlugin : Plugin<Project> {
                 createTasksForSourceSet(
                     project,
                     androidSourceSet.name,
-                    project.files(Callable { androidSourceSet.srcDirs })
-                )
+                    project.files(Callable { androidSourceSet.srcDirs }))
             }
         }
     }
 
-    private fun createTasksForSourceSet(project: Project, srcSetName: String, srcSetDir: FileCollection) {
-        val srcCheckTask = createCheckTask(
-            project,
-            ktfmtExtension,
-            srcSetName,
-            srcSetDir
-        )
-        val srcFormatTask = createFormatTask(
-            project,
-            ktfmtExtension,
-            srcSetName,
-            srcSetDir
-        )
+    private fun createTasksForSourceSet(
+        project: Project,
+        srcSetName: String,
+        srcSetDir: FileCollection
+    ) {
+        val srcCheckTask = createCheckTask(project, ktfmtExtension, srcSetName, srcSetDir)
+        val srcFormatTask = createFormatTask(project, ktfmtExtension, srcSetName, srcSetDir)
         topLevelFormat.configure { task -> task.dependsOn(srcFormatTask) }
         topLevelCheck.configure { task -> task.dependsOn(srcCheckTask) }
 
@@ -139,7 +129,8 @@ abstract class KtfmtPlugin : Plugin<Project> {
     private fun createTopLevelCheckTask(project: Project): TaskProvider<Task> {
         return project.tasks.register(TASK_NAME_CHECK) {
             it.group = "verification"
-            it.description = "Run Ktfmt validation for all source sets for project '${project.name}'"
+            it.description =
+                "Run Ktfmt validation for all source sets for project '${project.name}'"
         }
     }
 
@@ -152,7 +143,8 @@ abstract class KtfmtPlugin : Plugin<Project> {
         val capitalizedName = name.split(" ").joinToString("") { it.capitalize() }
         val taskName = "$TASK_NAME_CHECK$capitalizedName"
         return project.tasks.register(taskName, KtfmtCheckTask::class.java) {
-            it.description = "Run Ktfmt formatter for sourceSet '$name' on project '${project.name}'"
+            it.description =
+                "Run Ktfmt formatter for sourceSet '$name' on project '${project.name}'"
             it.setSource(srcDir)
             it.setIncludes(defaultIncludes)
             it.setExcludes(defaultExcludes)
@@ -169,7 +161,8 @@ abstract class KtfmtPlugin : Plugin<Project> {
         val srcSetName = name.split(" ").joinToString("") { it.capitalize() }
         val taskName = "$TASK_NAME_FORMAT$srcSetName"
         return project.tasks.register(taskName, KtfmtFormatTask::class.java) {
-            it.description = "Run Ktfmt formatter validation for sourceSet '$name' on project '${project.name}'"
+            it.description =
+                "Run Ktfmt formatter validation for sourceSet '$name' on project '${project.name}'"
             it.setSource(srcDir)
             it.setIncludes(defaultIncludes)
             it.setExcludes(defaultExcludes)
@@ -184,12 +177,13 @@ abstract class KtfmtPlugin : Plugin<Project> {
 }
 
 @Suppress("UnstableApiUsage")
-private typealias AndroidCommonExtension = CommonExtension<
-    AndroidSourceSet,
-    BuildFeatures,
-    BuildType,
-    DefaultConfig,
-    ProductFlavor,
-    SigningConfig,
-    Variant<VariantProperties>,
-    VariantProperties>
+private typealias AndroidCommonExtension =
+    CommonExtension<
+        AndroidSourceSet,
+        BuildFeatures,
+        BuildType,
+        DefaultConfig,
+        ProductFlavor,
+        SigningConfig,
+        Variant<VariantProperties>,
+        VariantProperties>

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
@@ -6,9 +6,7 @@ import com.ncorti.ktfmt.gradle.util.KtfmtUtils
 import com.ncorti.ktfmt.gradle.util.e
 import com.ncorti.ktfmt.gradle.util.i
 
-/**
- * ktfmt-gradle Check task. Verifies if the output of ktfmt is the same as the input
- */
+/** ktfmt-gradle Check task. Verifies if the output of ktfmt is the same as the input */
 abstract class KtfmtCheckTask : KtfmtBaseTask() {
 
     init {
@@ -19,12 +17,14 @@ abstract class KtfmtCheckTask : KtfmtBaseTask() {
         val result = processFileCollection(inputFiles)
         result.forEach {
             when {
-                it is KtfmtSuccess && it.isCorrectlyFormatted -> logger.i("Valid formatting for: ${it.input}")
+                it is KtfmtSuccess && it.isCorrectlyFormatted ->
+                    logger.i("Valid formatting for: ${it.input}")
                 it is KtfmtSuccess && !it.isCorrectlyFormatted -> {
                     logger.e("Invalid formatting for: ${it.input}")
                     printDiff(computeDiff(it), logger)
                 }
-                it is KtfmtFailure -> logger.e("Failing to format: ${it.input}\nError: ${it.message}", it.reason)
+                it is KtfmtFailure ->
+                    logger.e("Failing to format: ${it.input}\nError: ${it.message}", it.reason)
             }
         }
 
@@ -34,12 +34,13 @@ abstract class KtfmtCheckTask : KtfmtBaseTask() {
             error("Ktfmt failed to run with ${failures.size} failures")
         }
 
-        val notFormattedFiles = result.filterIsInstance<KtfmtSuccess>()
-            .filterNot(KtfmtSuccess::isCorrectlyFormatted)
+        val notFormattedFiles =
+            result.filterIsInstance<KtfmtSuccess>().filterNot(KtfmtSuccess::isCorrectlyFormatted)
 
         if (notFormattedFiles.isNotEmpty()) {
             val fileList = notFormattedFiles.map { it.input }.joinToString("\n")
-            error("[ktfmt] Found ${notFormattedFiles.size} files that are not properly formatted:\n$fileList")
+            error(
+                "[ktfmt] Found ${notFormattedFiles.size} files that are not properly formatted:\n$fileList")
         }
 
         logger.i("Successfully checked ${result.count()} files with Ktfmt")

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
@@ -5,9 +5,7 @@ import com.ncorti.ktfmt.gradle.util.e
 import com.ncorti.ktfmt.gradle.util.i
 import java.nio.charset.Charset
 
-/**
- * ktfmt-gradle Format task. Replaces input file content with its formatted equivalent.
- */
+/** ktfmt-gradle Format task. Replaces input file content with its formatted equivalent. */
 abstract class KtfmtFormatTask : KtfmtBaseTask() {
 
     init {
@@ -18,12 +16,14 @@ abstract class KtfmtFormatTask : KtfmtBaseTask() {
         val result = processFileCollection(inputFiles)
         result.forEach {
             when {
-                it is KtfmtSuccess && it.isCorrectlyFormatted -> logger.i("Valid formatting for: ${it.input}")
+                it is KtfmtSuccess && it.isCorrectlyFormatted ->
+                    logger.i("Valid formatting for: ${it.input}")
                 it is KtfmtSuccess && !it.isCorrectlyFormatted -> {
                     logger.i("Reformatting...: ${it.input}")
                     it.input.writeText(it.formattedCode, Charset.defaultCharset())
                 }
-                it is KtfmtFailure -> logger.e("Failing to format: ${it.input}\nError: ${it.message}")
+                it is KtfmtFailure ->
+                    logger.e("Failing to format: ${it.input}\nError: ${it.message}")
             }
         }
 
@@ -33,9 +33,8 @@ abstract class KtfmtFormatTask : KtfmtBaseTask() {
             error("Ktfmt failed to run with ${failures.size} failures")
         }
 
-        val notFormattedFiles = result
-            .filterIsInstance<KtfmtSuccess>()
-            .filterNot(KtfmtSuccess::isCorrectlyFormatted)
+        val notFormattedFiles =
+            result.filterIsInstance<KtfmtSuccess>().filterNot(KtfmtSuccess::isCorrectlyFormatted)
 
         logger.i("Successfully reformatted ${notFormattedFiles.count()} files with Ktfmt")
     }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtResult.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtResult.kt
@@ -1,7 +1,7 @@
 package com.ncorti.ktfmt.gradle.tasks
 
-import org.intellij.lang.annotations.Language
 import java.io.File
+import org.intellij.lang.annotations.Language
 
 internal sealed class KtfmtResult(open val input: File)
 

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/util/KtfmtDiffEntry.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/util/KtfmtDiffEntry.kt
@@ -2,8 +2,4 @@ package com.ncorti.ktfmt.gradle.util
 
 import java.io.File
 
-internal data class KtfmtDiffEntry(
-    val input: File,
-    val lineNumber: Int,
-    val message: String
-)
+internal data class KtfmtDiffEntry(val input: File, val lineNumber: Int, val message: String)

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/util/KtfmtDiffer.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/util/KtfmtDiffer.kt
@@ -14,12 +14,13 @@ internal object KtfmtDiffer {
         val output = formatterResult.formattedCode
         return DiffUtils.diff(input, output, null).deltas.map {
             val line = it.source.position + 1
-            val message: String = when (it) {
-                is ChangeDelta -> "Line changed: ${it.source.lines.first()}"
-                is DeleteDelta -> "Line deleted"
-                is InsertDelta -> "Line added"
-                else -> ""
-            }
+            val message: String =
+                when (it) {
+                    is ChangeDelta -> "Line changed: ${it.source.lines.first()}"
+                    is DeleteDelta -> "Line deleted"
+                    is InsertDelta -> "Line added"
+                    else -> ""
+                }
             KtfmtDiffEntry(formatterResult.input, line, message)
         }
     }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/util/KtfmtLogger.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/util/KtfmtLogger.kt
@@ -6,14 +6,16 @@ private const val TAG = "[ktfmt]"
 
 internal fun Logger.i(message: String) = this.info("$TAG $message")
 
-internal fun Logger.w(message: String, throwable: Throwable? = null) = if (throwable != null) {
-    this.warn("$TAG $message", throwable)
-} else {
-    this.warn("$TAG $message")
-}
+internal fun Logger.w(message: String, throwable: Throwable? = null) =
+    if (throwable != null) {
+        this.warn("$TAG $message", throwable)
+    } else {
+        this.warn("$TAG $message")
+    }
 
-internal fun Logger.e(message: String, throwable: Throwable? = null) = if (throwable != null) {
-    this.error("$TAG $message", throwable)
-} else {
-    this.error("$TAG $message")
-}
+internal fun Logger.e(message: String, throwable: Throwable? = null) =
+    if (throwable != null) {
+        this.error("$TAG $message", throwable)
+    } else {
+        this.error("$TAG $message")
+    }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/FormattingOptionsBeanTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/FormattingOptionsBeanTest.kt
@@ -7,13 +7,13 @@ class FormattingOptionsBeanTest {
 
     @Test
     fun `toFormattingOptions copies fields correctly`() {
-        val bean = FormattingOptionsBean(
-            maxWidth = 42,
-            blockIndent = 43,
-            continuationIndent = 44,
-            removeUnusedImports = false,
-            debuggingPrintOpsAfterFormatting = true
-        )
+        val bean =
+            FormattingOptionsBean(
+                maxWidth = 42,
+                blockIndent = 43,
+                continuationIndent = 44,
+                removeUnusedImports = false,
+                debuggingPrintOpsAfterFormatting = true)
 
         val opts = bean.toFormattingOptions()
 

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
@@ -43,7 +43,8 @@ class KtfmtExtensionTest {
     fun `debuggingPrintOpsAfterFormatting has default value`() {
         val extension = object : KtfmtExtension(ProjectBuilder.builder().build()) {}
 
-        assertThat(extension.debuggingPrintOpsAfterFormatting.get()).isEqualTo(DEFAULT_DEBUGGING_PRINT_OPTS)
+        assertThat(extension.debuggingPrintOpsAfterFormatting.get())
+            .isEqualTo(DEFAULT_DEBUGGING_PRINT_OPTS)
     }
 
     @Test

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtPluginTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtPluginTest.kt
@@ -32,8 +32,10 @@ class KtfmtPluginTest {
         assertThat(project["ktfmtCheckTest"]).isInstanceOf(KtfmtCheckTask::class.java)
         assertThat(project["ktfmtFormatTest"]).isInstanceOf(KtfmtFormatTask::class.java)
 
-        assertThat(project["ktfmtCheck"].dependencies).containsExactly("ktfmtCheckMain", "ktfmtCheckTest")
-        assertThat(project["ktfmtFormat"].dependencies).containsExactly("ktfmtFormatMain", "ktfmtFormatTest")
+        assertThat(project["ktfmtCheck"].dependencies)
+            .containsExactly("ktfmtCheckMain", "ktfmtCheckTest")
+        assertThat(project["ktfmtFormat"].dependencies)
+            .containsExactly("ktfmtFormatMain", "ktfmtFormatTest")
     }
 
     @Test
@@ -47,8 +49,10 @@ class KtfmtPluginTest {
         assertThat(project["ktfmtCheckTest"]).isInstanceOf(KtfmtCheckTask::class.java)
         assertThat(project["ktfmtFormatTest"]).isInstanceOf(KtfmtFormatTask::class.java)
 
-        assertThat(project["ktfmtCheck"].dependencies).containsExactly("ktfmtCheckMain", "ktfmtCheckTest")
-        assertThat(project["ktfmtFormat"].dependencies).containsExactly("ktfmtFormatMain", "ktfmtFormatTest")
+        assertThat(project["ktfmtCheck"].dependencies)
+            .containsExactly("ktfmtCheckMain", "ktfmtCheckTest")
+        assertThat(project["ktfmtFormat"].dependencies)
+            .containsExactly("ktfmtFormatMain", "ktfmtFormatTest")
     }
 
     @Test
@@ -57,19 +61,19 @@ class KtfmtPluginTest {
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         project.pluginManager.apply("com.ncorti.ktfmt.gradle")
 
-        assertThat(project.tasks.getByName("ktfmtCheckCommonMain")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatCommonMain")).isInstanceOf(KtfmtFormatTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtCheckCommonTest")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatCommonTest")).isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckCommonMain"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatCommonMain"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckCommonTest"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatCommonTest"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
 
-        assertThat(project["ktfmtCheck"].dependencies).containsExactly(
-            "ktfmtCheckCommonMain",
-            "ktfmtCheckCommonTest"
-        )
-        assertThat(project["ktfmtFormat"].dependencies).containsExactly(
-            "ktfmtFormatCommonMain",
-            "ktfmtFormatCommonTest"
-        )
+        assertThat(project["ktfmtCheck"].dependencies)
+            .containsExactly("ktfmtCheckCommonMain", "ktfmtCheckCommonTest")
+        assertThat(project["ktfmtFormat"].dependencies)
+            .containsExactly("ktfmtFormatCommonMain", "ktfmtFormatCommonTest")
     }
 
     @Test
@@ -85,56 +89,72 @@ class KtfmtPluginTest {
         }
 
         // AndroidTest
-        assertThat(project.tasks.getByName("ktfmtCheckAndroidTestDebugJavaSource")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtCheckAndroidTestReleaseJavaSource")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtCheckAndroidTestJavaSource")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatAndroidTestDebugJavaSource")).isInstanceOf(KtfmtFormatTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatAndroidTestReleaseJavaSource")).isInstanceOf(KtfmtFormatTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatAndroidTestJavaSource")).isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckAndroidTestDebugJavaSource"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckAndroidTestReleaseJavaSource"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckAndroidTestJavaSource"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatAndroidTestDebugJavaSource"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatAndroidTestReleaseJavaSource"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatAndroidTestJavaSource"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
 
         // Test
-        assertThat(project.tasks.getByName("ktfmtCheckTestDebugJavaSource")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtCheckTestReleaseJavaSource")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtCheckTestJavaSource")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatTestDebugJavaSource")).isInstanceOf(KtfmtFormatTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatTestReleaseJavaSource")).isInstanceOf(KtfmtFormatTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatTestJavaSource")).isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckTestDebugJavaSource"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckTestReleaseJavaSource"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckTestJavaSource"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatTestDebugJavaSource"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatTestReleaseJavaSource"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatTestJavaSource"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
 
         // Prod
-        assertThat(project.tasks.getByName("ktfmtCheckDebugJavaSource")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtCheckReleaseJavaSource")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtCheckMainJavaSource")).isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatDebugJavaSource")).isInstanceOf(KtfmtFormatTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatReleaseJavaSource")).isInstanceOf(KtfmtFormatTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatMainJavaSource")).isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckDebugJavaSource"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckReleaseJavaSource"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtCheckMainJavaSource"))
+            .isInstanceOf(KtfmtCheckTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatDebugJavaSource"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatReleaseJavaSource"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
+        assertThat(project.tasks.getByName("ktfmtFormatMainJavaSource"))
+            .isInstanceOf(KtfmtFormatTask::class.java)
 
-        assertThat(project["ktfmtCheck"].dependencies).containsExactly(
-            "ktfmtCheckAndroidTestDebugJavaSource",
-            "ktfmtCheckAndroidTestReleaseJavaSource",
-            "ktfmtCheckAndroidTestJavaSource",
-            "ktfmtCheckTestDebugJavaSource",
-            "ktfmtCheckTestReleaseJavaSource",
-            "ktfmtCheckTestJavaSource",
-            "ktfmtCheckDebugJavaSource",
-            "ktfmtCheckReleaseJavaSource",
-            "ktfmtCheckMainJavaSource"
-        )
-        assertThat(project["ktfmtFormat"].dependencies).containsExactly(
-            "ktfmtFormatAndroidTestDebugJavaSource",
-            "ktfmtFormatAndroidTestReleaseJavaSource",
-            "ktfmtFormatAndroidTestJavaSource",
-            "ktfmtFormatTestDebugJavaSource",
-            "ktfmtFormatTestReleaseJavaSource",
-            "ktfmtFormatTestJavaSource",
-            "ktfmtFormatDebugJavaSource",
-            "ktfmtFormatReleaseJavaSource",
-            "ktfmtFormatMainJavaSource"
-        )
+        assertThat(project["ktfmtCheck"].dependencies)
+            .containsExactly(
+                "ktfmtCheckAndroidTestDebugJavaSource",
+                "ktfmtCheckAndroidTestReleaseJavaSource",
+                "ktfmtCheckAndroidTestJavaSource",
+                "ktfmtCheckTestDebugJavaSource",
+                "ktfmtCheckTestReleaseJavaSource",
+                "ktfmtCheckTestJavaSource",
+                "ktfmtCheckDebugJavaSource",
+                "ktfmtCheckReleaseJavaSource",
+                "ktfmtCheckMainJavaSource")
+        assertThat(project["ktfmtFormat"].dependencies)
+            .containsExactly(
+                "ktfmtFormatAndroidTestDebugJavaSource",
+                "ktfmtFormatAndroidTestReleaseJavaSource",
+                "ktfmtFormatAndroidTestJavaSource",
+                "ktfmtFormatTestDebugJavaSource",
+                "ktfmtFormatTestReleaseJavaSource",
+                "ktfmtFormatTestJavaSource",
+                "ktfmtFormatDebugJavaSource",
+                "ktfmtFormatReleaseJavaSource",
+                "ktfmtFormatMainJavaSource")
     }
 
     private operator fun Project.get(value: String): Task = this.tasks.getByName(value)
     private val Task.dependencies: List<String>
-        get() = this.dependsOn
-            .filterIsInstance<TaskProvider<*>>()
-            .map { it.name }
+        get() = this.dependsOn.filterIsInstance<TaskProvider<*>>().map { it.name }
 }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTaskTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTaskTest.kt
@@ -2,6 +2,7 @@ package com.ncorti.ktfmt.gradle.tasks
 
 import com.facebook.ktfmt.ParseError
 import com.google.common.truth.Truth.assertThat
+import java.io.File
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
@@ -9,14 +10,12 @@ import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import java.io.File
 
 internal class KtfmtBaseTaskTest {
 
     private lateinit var project: Project
 
-    @TempDir
-    lateinit var tempDir: File
+    @TempDir lateinit var tempDir: File
 
     @BeforeEach
     fun setUp() {
@@ -103,40 +102,43 @@ internal class KtfmtBaseTaskTest {
     }
 
     @Test
-    fun `processFileCollection with multiple files works correctly`() = runBlocking {
-        val underTest = project.tasks.getByName("ktfmtFormatMain") as KtfmtBaseTask
+    fun `processFileCollection with multiple files works correctly`() =
+        runBlocking {
+            val underTest = project.tasks.getByName("ktfmtFormatMain") as KtfmtBaseTask
 
-        val input1 = createTempFile(fileName = "file1.kt", content = "val hello = 1\n")
-        val input2 = createTempFile(fileName = "file2.kt", content = "val hello = 2")
+            val input1 = createTempFile(fileName = "file1.kt", content = "val hello = 1\n")
+            val input2 = createTempFile(fileName = "file2.kt", content = "val hello = 2")
 
-        val result = underTest.processFileCollection(project.files(input1, input2))
+            val result = underTest.processFileCollection(project.files(input1, input2))
 
-        assertThat(result).hasSize(2)
-        assertThat(result.filterIsInstance<KtfmtSuccess>()).hasSize(2)
-        assertThat((result[0] as KtfmtSuccess).isCorrectlyFormatted).isTrue()
-        assertThat((result[1] as KtfmtSuccess).isCorrectlyFormatted).isFalse()
-    }
+            assertThat(result).hasSize(2)
+            assertThat(result.filterIsInstance<KtfmtSuccess>()).hasSize(2)
+            assertThat((result[0] as KtfmtSuccess).isCorrectlyFormatted).isTrue()
+            assertThat((result[1] as KtfmtSuccess).isCorrectlyFormatted).isFalse()
+        }
 
     @Test
-    fun `processFileCollection with a failure keeps on formatting`() = runBlocking {
-        val underTest = project.tasks.getByName("ktfmtFormatMain") as KtfmtBaseTask
+    fun `processFileCollection with a failure keeps on formatting`() =
+        runBlocking {
+            val underTest = project.tasks.getByName("ktfmtFormatMain") as KtfmtBaseTask
 
-        val input1 = createTempFile(fileName = "file1.kt", content = "val hello = 1\n")
-        val input2 = createTempFile(fileName = "file2.kt", content = "val hello=`")
+            val input1 = createTempFile(fileName = "file1.kt", content = "val hello = 1\n")
+            val input2 = createTempFile(fileName = "file2.kt", content = "val hello=`")
 
-        val result = underTest.processFileCollection(project.files(input1, input2))
+            val result = underTest.processFileCollection(project.files(input1, input2))
 
-        assertThat(result).hasSize(2)
-        assertThat(result.filterIsInstance<KtfmtSuccess>()).hasSize(1)
-        assertThat((result[0] as KtfmtSuccess).isCorrectlyFormatted).isTrue()
-        assertThat((result[1] as KtfmtFailure).reason).isInstanceOf(ParseError::class.java)
-    }
+            assertThat(result).hasSize(2)
+            assertThat(result.filterIsInstance<KtfmtSuccess>()).hasSize(1)
+            assertThat((result[0] as KtfmtSuccess).isCorrectlyFormatted).isTrue()
+            assertThat((result[1] as KtfmtFailure).reason).isInstanceOf(ParseError::class.java)
+        }
 
     private fun createTempFile(
         @Language("kotlin") content: String,
         fileName: String = "TestFile.kt"
-    ): File = File(tempDir, fileName).apply {
-        createNewFile()
-        writeText(content)
-    }
+    ): File =
+        File(tempDir, fileName).apply {
+            createNewFile()
+            writeText(content)
+        }
 }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.ncorti.ktfmt.gradle.tasks
 
 import com.google.common.truth.Truth.assertThat
+import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -9,12 +10,10 @@ import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import java.io.File
 
 internal class KtfmtCheckTaskIntegrationTest {
 
-    @TempDir
-    lateinit var tempDir: File
+    @TempDir lateinit var tempDir: File
 
     @BeforeEach
     fun setUp() {
@@ -25,10 +24,12 @@ internal class KtfmtCheckTaskIntegrationTest {
     @Test
     fun `check task fails if there is invalid code`() {
         createTempFile(content = "val answer = `")
-        val result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtCheckMain")
-            .buildAndFail()
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain")
+                .buildAndFail()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(FAILED)
         assertThat(result.output).contains("Error: Failed to parse file")
@@ -37,10 +38,12 @@ internal class KtfmtCheckTaskIntegrationTest {
     @Test
     fun `check task fails if there is not formatted code`() {
         createTempFile(content = "val answer=42")
-        val result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtCheckMain")
-            .buildAndFail()
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain")
+                .buildAndFail()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(FAILED)
         assertThat(result.output).contains("[ktfmt] Invalid formatting")
@@ -49,10 +52,12 @@ internal class KtfmtCheckTaskIntegrationTest {
     @Test
     fun `check task succeed if code is formatted`() {
         createTempFile(content = "val answer = 42\n")
-        val result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtCheckMain")
-            .build()
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain")
+                .build()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
     }
@@ -60,17 +65,21 @@ internal class KtfmtCheckTaskIntegrationTest {
     @Test
     fun `check task is up to date after subsequent execution`() {
         createTempFile(content = "val answer = 42\n")
-        var result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtCheckMain")
-            .build()
+        var result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain")
+                .build()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
 
-        result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtCheckMain")
-            .build()
+        result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain")
+                .build()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(UP_TO_DATE)
     }
@@ -78,27 +87,33 @@ internal class KtfmtCheckTaskIntegrationTest {
     @Test
     fun `check task is up to executed again after edit`() {
         val tempFile = createTempFile(content = "val answer = 42\n")
-        var result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtCheckMain")
-            .build()
+        var result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain")
+                .build()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
 
-        result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtCheckMain")
-            .build()
+        result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain")
+                .build()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(UP_TO_DATE)
 
         // Let's change file content
         tempFile.writeText("val answer = 43\n")
 
-        result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtCheckMain")
-            .build()
+        result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain")
+                .build()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
     }
@@ -106,11 +121,12 @@ internal class KtfmtCheckTaskIntegrationTest {
     @Test
     fun `check task prints formatted files with --info`() {
         val tempFile = createTempFile(content = "val answer = 42\n")
-        val result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-
-            .withArguments("ktfmtCheckMain", "--info")
-            .build()
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain", "--info")
+                .build()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
         assertThat(result.output).contains("[ktfmt] Successfully checked 1 files with Ktfmt")
@@ -122,10 +138,12 @@ internal class KtfmtCheckTaskIntegrationTest {
         createTempFile(content = "val answer = `\n", fileName = "File1.kt")
         createTempFile(content = "val answer = 42\n", fileName = "File2.kt")
 
-        val result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtCheckMain", "--info")
-            .buildAndFail()
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain", "--info")
+                .buildAndFail()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(FAILED)
         assertThat(result.output).contains("Failed to parse file:")
@@ -136,8 +154,9 @@ internal class KtfmtCheckTaskIntegrationTest {
         @Language("kotlin") content: String,
         fileName: String = "TestFile.kt",
         path: String = "src/main/java"
-    ) = File(File(tempDir, path), fileName).apply {
-        createNewFile()
-        writeText(content)
-    }
+    ) =
+        File(File(tempDir, path), fileName).apply {
+            createNewFile()
+            writeText(content)
+        }
 }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.ncorti.ktfmt.gradle.tasks
 
 import com.google.common.truth.Truth.assertThat
+import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -9,12 +10,10 @@ import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import java.io.File
 
 internal class KtfmtFormatTaskIntegrationTest {
 
-    @TempDir
-    lateinit var tempDir: File
+    @TempDir lateinit var tempDir: File
 
     @BeforeEach
     fun setUp() {
@@ -25,10 +24,12 @@ internal class KtfmtFormatTaskIntegrationTest {
     @Test
     fun `format task fails if there is invalid code`() {
         createTempFile(content = "val answer = `")
-        val result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .buildAndFail()
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .buildAndFail()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(FAILED)
         assertThat(result.output).contains("Error: Failed to parse file")
@@ -37,10 +38,12 @@ internal class KtfmtFormatTaskIntegrationTest {
     @Test
     fun `format formats correctly`() {
         val tempFile = createTempFile(content = "val answer=42")
-        val result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .build()
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .build()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
         assertThat(tempFile.readText()).isEqualTo("val answer = 42\n")
@@ -49,10 +52,12 @@ internal class KtfmtFormatTaskIntegrationTest {
     @Test
     fun `format task succeed if code is formatted`() {
         createTempFile(content = "val answer = 42\n")
-        val result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .build()
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .build()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
     }
@@ -60,17 +65,21 @@ internal class KtfmtFormatTaskIntegrationTest {
     @Test
     fun `format task is up to date after subsequent execution`() {
         createTempFile(content = "val answer = 42\n")
-        var result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .build()
+        var result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .build()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
 
-        result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .build()
+        result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .build()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(UP_TO_DATE)
     }
@@ -78,50 +87,62 @@ internal class KtfmtFormatTaskIntegrationTest {
     @Test
     fun `format task is up to date after subsequent execution when formatting`() {
         createTempFile(content = "val answer=42")
-        var result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .build()
+        var result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .build()
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
 
         // This run will be triggered as we modified the input (reformatting the file)
-        result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .build()
+        result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .build()
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
 
-        result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .build()
+        result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .build()
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(UP_TO_DATE)
     }
 
     @Test
     fun `format task is up to executed again after edit`() {
         val tempFile = createTempFile(content = "val answer = 42\n")
-        var result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .build()
+        var result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .build()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
 
-        result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .build()
+        result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .build()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(UP_TO_DATE)
 
         // Let's change file content
         tempFile.writeText("val answer=42\n")
 
-        result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain")
-            .build()
+        result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain")
+                .build()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
         assertThat(tempFile.readText()).isEqualTo("val answer = 42\n")
@@ -130,11 +151,12 @@ internal class KtfmtFormatTaskIntegrationTest {
     @Test
     fun `format task prints formatted files with --info`() {
         createTempFile(content = "val answer=42\n")
-        val result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-
-            .withArguments("ktfmtFormatMain", "--info")
-            .build()
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain", "--info")
+                .build()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
         assertThat(result.output).contains("[ktfmt] Reformatting...")
@@ -146,10 +168,12 @@ internal class KtfmtFormatTaskIntegrationTest {
         val file1 = createTempFile(content = "val answer = `", fileName = "File1.kt")
         val file2 = createTempFile(content = "val answer=42", fileName = "File2.kt")
 
-        val result = GradleRunner.create().withProjectDir(tempDir)
-            .withPluginClasspath()
-            .withArguments("ktfmtFormatMain", "--info")
-            .buildAndFail()
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain", "--info")
+                .buildAndFail()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(FAILED)
 
@@ -164,8 +188,9 @@ internal class KtfmtFormatTaskIntegrationTest {
         @Language("kotlin") content: String,
         fileName: String = "TestFile.kt",
         path: String = "src/main/java"
-    ) = File(File(tempDir, path), fileName).apply {
-        createNewFile()
-        writeText(content)
-    }
+    ) =
+        File(File(tempDir, path), fileName).apply {
+            createNewFile()
+            writeText(content)
+        }
 }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/util/KtfmtDifferTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/util/KtfmtDifferTest.kt
@@ -2,27 +2,22 @@ package com.ncorti.ktfmt.gradle.util
 
 import com.google.common.truth.Truth.assertThat
 import com.ncorti.ktfmt.gradle.tasks.KtfmtSuccess
+import java.io.File
 import org.gradle.testfixtures.ProjectBuilder
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import java.io.File
 
 internal class KtfmtDifferTest {
 
-    @TempDir
-    lateinit var tempDir: File
+    @TempDir lateinit var tempDir: File
 
     val logger = TestLogger(ProjectBuilder.builder().build())
 
     @Test
     fun `computeDiff with empty diff returns empty`() {
         val inputFile = createTempFile(content = "")
-        val input = KtfmtSuccess(
-            inputFile,
-            isCorrectlyFormatted = true,
-            formattedCode = ""
-        )
+        val input = KtfmtSuccess(inputFile, isCorrectlyFormatted = true, formattedCode = "")
 
         val diff = KtfmtDiffer.computeDiff(input)
 
@@ -31,20 +26,21 @@ internal class KtfmtDifferTest {
 
     @Test
     fun `computeDiff with deleted line returns valid diff`() {
-        val inputFile = createTempFile(
-            content = """
+        val inputFile =
+            createTempFile(
+                content =
+                    """
                 val a = "So long,"
                 val b = "and thanks for all the fish!"
-            """.trimIndent()
-        )
+            """.trimIndent())
 
-        val input = KtfmtSuccess(
-            inputFile,
-            isCorrectlyFormatted = false,
-            formattedCode = """
+        val input =
+            KtfmtSuccess(
+                inputFile,
+                isCorrectlyFormatted = false,
+                formattedCode = """
                 val a = "So long,"
-            """.trimIndent()
-        )
+            """.trimIndent())
 
         val diff = KtfmtDiffer.computeDiff(input)
 
@@ -55,20 +51,21 @@ internal class KtfmtDifferTest {
 
     @Test
     fun `computeDiff with added line returns valid diff`() {
-        val inputFile = createTempFile(
-            content = """
+        val inputFile =
+            createTempFile(
+                content = """
                 val a = "So long,"
-            """.trimIndent()
-        )
+            """.trimIndent())
 
-        val input = KtfmtSuccess(
-            inputFile,
-            isCorrectlyFormatted = false,
-            formattedCode = """
+        val input =
+            KtfmtSuccess(
+                inputFile,
+                isCorrectlyFormatted = false,
+                formattedCode =
+                    """
                 val a = "So long,"
                 val b = "and thanks for all the fish!"
-            """.trimIndent()
-        )
+            """.trimIndent())
 
         val diff = KtfmtDiffer.computeDiff(input)
 
@@ -79,21 +76,23 @@ internal class KtfmtDifferTest {
 
     @Test
     fun `computeDiff with changed line returns valid diff`() {
-        val inputFile = createTempFile(
-            content = """
+        val inputFile =
+            createTempFile(
+                content =
+                    """
                   val a = "So long,"
                 val b = "and thanks for all the fish!"
-            """.trimIndent()
-        )
+            """.trimIndent())
 
-        val input = KtfmtSuccess(
-            inputFile,
-            isCorrectlyFormatted = false,
-            formattedCode = """
+        val input =
+            KtfmtSuccess(
+                inputFile,
+                isCorrectlyFormatted = false,
+                formattedCode =
+                    """
                 val a = "So long,"
                 val b = "and thanks for all the fish!"
-            """.trimIndent()
-        )
+            """.trimIndent())
 
         val diff = KtfmtDiffer.computeDiff(input)
 
@@ -104,23 +103,25 @@ internal class KtfmtDifferTest {
 
     @Test
     fun `computeDiff with multiple changed lines returns multiple entries`() {
-        val inputFile = createTempFile(
-            content = """
+        val inputFile =
+            createTempFile(
+                content =
+                    """
                    val a = "So long,"
                 val b = "and thanks!"
                  val c = "for all the fish!"
-            """.trimIndent()
-        )
+            """.trimIndent())
 
-        val input = KtfmtSuccess(
-            inputFile,
-            isCorrectlyFormatted = false,
-            formattedCode = """
+        val input =
+            KtfmtSuccess(
+                inputFile,
+                isCorrectlyFormatted = false,
+                formattedCode =
+                    """
                 val a = "So long,"
                 val b = "and thanks!"
                 val c = "for all the fish!"
-            """.trimIndent()
-        )
+            """.trimIndent())
 
         val diff = KtfmtDiffer.computeDiff(input)
 
@@ -134,15 +135,8 @@ internal class KtfmtDifferTest {
 
     @Test
     fun `printDiff adds valid line numbers`() {
-        val inputFile = createTempFile(
-            content = "val a = 42\nval b = 24",
-            fileName = "TestFile.kt"
-        )
-        val input = KtfmtSuccess(
-            inputFile,
-            false,
-            "val a = 42"
-        )
+        val inputFile = createTempFile(content = "val a = 42\nval b = 24", fileName = "TestFile.kt")
+        val input = KtfmtSuccess(inputFile, false, "val a = 42")
 
         KtfmtDiffer.printDiff(KtfmtDiffer.computeDiff(input), logger)
 
@@ -153,8 +147,9 @@ internal class KtfmtDifferTest {
     private fun createTempFile(
         @Language("kotlin") content: String,
         fileName: String = "TestFile.kt"
-    ): File = File(tempDir, fileName).apply {
-        createNewFile()
-        writeText(content)
-    }
+    ): File =
+        File(tempDir, fileName).apply {
+            createNewFile()
+            writeText(content)
+        }
 }


### PR DESCRIPTION
## 🚀 Description
Let's use version `0.2.0` of the plugin to reformat the `plugin` module itself.

## 📄 Motivation and Context
To reformat the `plugin` module, we will use a previously published version of the plugin (`0.2.0` in this case) taken from Gradle Portal.

## 🧪 How Has This Been Tested?
The `preMerge` task will run the `ktfmtCheck` task to verify the formatting.