### PR TITLE
Bump multiple dependencies

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,13 +1,11 @@
 object Versions {
-    const val KTLINT = "0.39.0"
-    const val JUPITER = "5.7.0"
+    const val JUPITER = "5.7.1"
 }
 
 object BuildPluginsVersion {
     const val DETEKT = "1.15.0"
     const val KOTLIN = "1.4.21"
-    const val KTLINT = "9.4.1"
-    const val VERSIONS_PLUGIN = "0.33.0"
+    const val VERSIONS_PLUGIN = "0.36.0"
 }
 
 object TestingLib {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -1,19 +1,19 @@
 object Versions {
-    const val AGP = "4.1.1"
+    const val AGP = "4.1.2"
     const val COROUTINES = "1.4.2"
     const val DIFF_UTIL = "4.9"
-    const val JUPITER = "5.7.0"
+    const val JUPITER = "5.7.1"
     const val KTFMT = "0.20"
-    const val TRUTH = "1.1"
+    const val TRUTH = "1.1.2"
 }
 
 object BuildPluginsVersion {
-    const val BINARY_COMPATIBILITY_VALIDATOR = "0.2.4"
+    const val BINARY_COMPATIBILITY_VALIDATOR = "0.4.0"
     const val DETEKT = "1.15.0"
     const val KOTLIN = "1.4.21"
     const val KTFMT = "0.2.0"
-    const val PLUGIN_PUBLISH = "0.12.0"
-    const val VERSIONS_PLUGIN = "0.33.0"
+    const val PLUGIN_PUBLISH = "0.13.0"
+    const val VERSIONS_PLUGIN = "0.36.0"
 }
 
 object Libs {

--- a/plugin-build/gradle/wrapper/gradle-wrapper.properties
+++ b/plugin-build/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 🚀 Description

- Gradle to 6.8.2
- Jupiter to 5.7.1
- Gradle to 6.8.2
- AGP to 4.1.2
- Truth to 1.1.2
- Binary compatibility validator to 0.4.0
- Publish plugin to 0.13.0
- Versions plugin to 0.36.0