### PR TITLE
Bump KtFmt to 0.21 and introduce kotlinLangStyle()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 This file follows [Keepachangelog](https://keepachangelog.com/) format.
 Please add your entries according to this format.
 
+## Unreleased
+
+### New features
+
+- Added the `kotlinLangStyle()` function to the `ktfmt{}` extension. This will allow you to apply a format that attempts to reflect the [official kotlin convetions](https://kotlinlang.org/docs/coding-conventions.html).
+
+### Dependencies Update
+
+- Ktfmt to 0.21
+
 ## Version 0.3.0 *(2021-02-23)*
 
 ### Dependencies Update

--- a/README.md
+++ b/README.md
@@ -85,11 +85,18 @@ example, the `ktfmtCheckAndroidTestDebugJavaSource`.
 
 You can configure the behavior of the `ktfmt` invocation with the `ktfmt` block in your `build.gradle.[kts]` file.
 
-To enable **dropbox style** (4 spaces indentation) you should simply:
+To enable different styles you can simply:
 
 ```kotlin
 ktfmt {
+    // Dropbox style - 4 space indentation
     dropboxStyle()
+    
+    // Google style - 2 space indentation
+    googleStyle()
+    
+    // KotlinLang style - 4 space indentation - From kotlinlang.org/docs/coding-conventions.html
+    kotlinLangStyle()
 }
 ```
 

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 ktfmt {
-    dropboxStyle()
+    kotlinLangStyle()
 }
 
 dependencies {

--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val COROUTINES = "1.4.2"
     const val DIFF_UTIL = "4.9"
     const val JUPITER = "5.7.1"
-    const val KTFMT = "0.20"
+    const val KTFMT = "0.21"
     const val TRUTH = "1.1.2"
 }
 

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -8,6 +8,7 @@ public abstract class com/ncorti/ktfmt/gradle/KtfmtExtension {
 	public final fun getMaxWidth ()Lorg/gradle/api/provider/Property;
 	public final fun getRemoveUnusedImports ()Lorg/gradle/api/provider/Property;
 	public final fun googleStyle ()V
+	public final fun kotlinLangStyle ()V
 }
 
 public abstract class com/ncorti/ktfmt/gradle/KtfmtPlugin : org/gradle/api/Plugin {

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
@@ -8,7 +8,7 @@ import java.io.Serializable
 internal data class FormattingOptionsBean(
 
     /** The style used by ktfmt */
-    val style : Style = Style.FACEBOOK,
+    val style: Style = Style.FACEBOOK,
 
     /** ktfmt breaks lines longer than maxWidth. */
     val maxWidth: Int = DEFAULT_MAX_WIDTH,
@@ -59,10 +59,11 @@ internal data class FormattingOptionsBean(
         FACEBOOK,
         DROPBOX,
         GOOGLE;
-        fun toKtfmtStyle() : KtfmtStyle = when(this) {
-            FACEBOOK -> KtfmtStyle.FACEBOOK
-            DROPBOX -> KtfmtStyle.DROPBOX
-            GOOGLE -> KtfmtStyle.GOOGLE
-        }
+        fun toKtfmtStyle(): KtfmtStyle =
+            when (this) {
+                FACEBOOK -> KtfmtStyle.FACEBOOK
+                DROPBOX -> KtfmtStyle.DROPBOX
+                GOOGLE -> KtfmtStyle.GOOGLE
+            }
     }
 }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
@@ -2,9 +2,13 @@ package com.ncorti.ktfmt.gradle
 
 import com.facebook.ktfmt.DEFAULT_MAX_WIDTH
 import com.facebook.ktfmt.FormattingOptions
+import com.facebook.ktfmt.FormattingOptions.Style as KtfmtStyle
 import java.io.Serializable
 
 internal data class FormattingOptionsBean(
+
+    /** The style used by ktfmt */
+    val style : Style = Style.FACEBOOK,
 
     /** ktfmt breaks lines longer than maxWidth. */
     val maxWidth: Int = DEFAULT_MAX_WIDTH,
@@ -44,9 +48,21 @@ internal data class FormattingOptionsBean(
 ) : Serializable {
     fun toFormattingOptions(): FormattingOptions =
         FormattingOptions(
+            style = style.toKtfmtStyle(),
             maxWidth = maxWidth,
             blockIndent = blockIndent,
             continuationIndent = continuationIndent,
             removeUnusedImports = removeUnusedImports,
             debuggingPrintOpsAfterFormatting = debuggingPrintOpsAfterFormatting)
+
+    enum class Style {
+        FACEBOOK,
+        DROPBOX,
+        GOOGLE;
+        fun toKtfmtStyle() : KtfmtStyle = when(this) {
+            FACEBOOK -> KtfmtStyle.FACEBOOK
+            DROPBOX -> KtfmtStyle.DROPBOX
+            GOOGLE -> KtfmtStyle.GOOGLE
+        }
+    }
 }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
@@ -1,5 +1,7 @@
 package com.ncorti.ktfmt.gradle
 
+import com.ncorti.ktfmt.gradle.FormattingOptionsBean.Style
+import com.ncorti.ktfmt.gradle.FormattingOptionsBean.Style.*
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
@@ -9,6 +11,8 @@ import org.gradle.api.provider.Property
 abstract class KtfmtExtension @Inject constructor(project: Project) {
 
     private val objects = project.objects
+
+    internal var ktfmtStyle = FACEBOOK
 
     /** ktfmt breaks lines longer than maxWidth. Default 100. */
     val maxWidth: Property<Int> = objects.property(Int::class.java).convention(DEFAULT_MAX_WIDTH)
@@ -53,6 +57,7 @@ abstract class KtfmtExtension @Inject constructor(project: Project) {
     /** Enables --dropbox-style (equivalent to set blockIndent to 4 and continuationIndent to 4). */
     @Suppress("MagicNumber")
     fun dropboxStyle() {
+        ktfmtStyle = DROPBOX
         blockIndent.set(4)
         continuationIndent.set(4)
     }
@@ -60,12 +65,25 @@ abstract class KtfmtExtension @Inject constructor(project: Project) {
     /** Sets the Google style (equivalent to set blockIndent to 2 and continuationIndent to 2). */
     @Suppress("MagicNumber")
     fun googleStyle() {
+        ktfmtStyle = GOOGLE
         blockIndent.set(2)
         continuationIndent.set(2)
     }
 
+    /**
+     * Sets the KotlinLang style.
+     * A format that attempts to reflect https://kotlinlang.org/docs/coding-conventions.html.
+     */
+    @Suppress("MagicNumber")
+    fun kotlinLangStyle() {
+        ktfmtStyle = GOOGLE
+        blockIndent.set(4)
+        continuationIndent.set(4)
+    }
+
     internal fun toBean(): FormattingOptionsBean =
         FormattingOptionsBean(
+            style = ktfmtStyle,
             maxWidth = maxWidth.get(),
             blockIndent = blockIndent.get(),
             continuationIndent = continuationIndent.get(),

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
@@ -1,7 +1,8 @@
 package com.ncorti.ktfmt.gradle
 
-import com.ncorti.ktfmt.gradle.FormattingOptionsBean.Style
-import com.ncorti.ktfmt.gradle.FormattingOptionsBean.Style.*
+import com.ncorti.ktfmt.gradle.FormattingOptionsBean.Style.DROPBOX
+import com.ncorti.ktfmt.gradle.FormattingOptionsBean.Style.FACEBOOK
+import com.ncorti.ktfmt.gradle.FormattingOptionsBean.Style.GOOGLE
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
@@ -71,8 +72,8 @@ abstract class KtfmtExtension @Inject constructor(project: Project) {
     }
 
     /**
-     * Sets the KotlinLang style.
-     * A format that attempts to reflect https://kotlinlang.org/docs/coding-conventions.html.
+     * Sets the KotlinLang style. A format that attempts to reflect
+     * https://kotlinlang.org/docs/coding-conventions.html.
      */
     @Suppress("MagicNumber")
     fun kotlinLangStyle() {

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
@@ -1,6 +1,7 @@
 package com.ncorti.ktfmt.gradle
 
 import com.google.common.truth.Truth.assertThat
+import com.ncorti.ktfmt.gradle.FormattingOptionsBean.Style.*
 import com.ncorti.ktfmt.gradle.KtfmtExtension.Companion.DEFAULT_BLOCK_INDENT
 import com.ncorti.ktfmt.gradle.KtfmtExtension.Companion.DEFAULT_CONTINUATION_INDENT
 import com.ncorti.ktfmt.gradle.KtfmtExtension.Companion.DEFAULT_DEBUGGING_PRINT_OPTS
@@ -55,6 +56,7 @@ class KtfmtExtensionTest {
 
         assertThat(extension.blockIndent.get()).isEqualTo(4)
         assertThat(extension.continuationIndent.get()).isEqualTo(4)
+        assertThat(extension.ktfmtStyle).isEqualTo(DROPBOX)
     }
 
     @Test
@@ -65,6 +67,18 @@ class KtfmtExtensionTest {
 
         assertThat(extension.blockIndent.get()).isEqualTo(2)
         assertThat(extension.continuationIndent.get()).isEqualTo(2)
+        assertThat(extension.ktfmtStyle).isEqualTo(GOOGLE)
+    }
+
+    @Test
+    fun `kotlinLangStyle configures correctly`() {
+        val extension = object : KtfmtExtension(ProjectBuilder.builder().build()) {}
+
+        extension.kotlinLangStyle()
+
+        assertThat(extension.blockIndent.get()).isEqualTo(4)
+        assertThat(extension.continuationIndent.get()).isEqualTo(4)
+        assertThat(extension.ktfmtStyle).isEqualTo(GOOGLE)
     }
 
     @Test


### PR DESCRIPTION
## 🚀 Description
Bump Ktfmt to 0.21 and introduce new features.

## 📄 Motivation and Context
The plugin now mirrors the `--kotlinlang-style` flag introduced in: https://github.com/facebookincubator/ktfmt/releases/tag/v0.21

You can enable it with:

```kotlin
ktfmt {
    kotlinLangStyle()
}
```

## 🧪 How Has This Been Tested?
JUnit tests are attached.

## 📦 Types of changes
- [x] New feature (non-breaking change which adds functionality)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.