### PR TITLE
Add support for --include-only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,29 @@ ktfmt {
 }
 ```
 
+## Using with a pre-commit hook 🎣
+
+You can leverage the `--include-only` to let ktfmt-gradle run only on a specific subset of files.
+
+To this you can register a simple task of type `KtfmtCheckTask` or `KtfmtFormatTask` in your `build.gradle.kts` as follows:
+
+```kotlin
+import com.ncorti.ktfmt.gradle.tasks.*
+
+tasks.register<KtfmtFormatTask>("ktfmtPrecommit") {
+    source = project.fileTree(rootDir)
+    include("**/*.kt")
+}
+```
+
+You can then invoke the task with `--include-only` and a comma separated list of relative path of files:
+
+```
+./gradlew ktfmtPrecommit --include-only=src/main/java/File1.kt:src/main/java/File2.kt
+```
+
+The task will execute only on the file you passed and will skip all the others.
+
 ## Contributing 🤝
 
 Feel free to open a issue or submit a pull request for any bugs/improvements.

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,4 +1,3 @@
-
 plugins {
     kotlin("jvm")
     id("com.ncorti.ktfmt.gradle")

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,3 +1,4 @@
+
 plugins {
     kotlin("jvm")
     id("com.ncorti.ktfmt.gradle")

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -24,6 +24,7 @@ public final class com/ncorti/ktfmt/gradle/KtfmtPlugin$Companion {
 public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask : org/gradle/api/tasks/SourceTask {
 	public fun <init> ()V
 	protected abstract fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getIncludeOnly ()Lorg/gradle/api/provider/Property;
 	protected final fun getInputFiles ()Lorg/gradle/api/file/FileCollection;
 	protected final fun getOutputFiles ()Lorg/gradle/api/file/FileCollection;
 }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
@@ -23,6 +23,7 @@ abstract class KtfmtCheckTask : KtfmtBaseTask() {
                     logger.e("Invalid formatting for: ${it.input}")
                     printDiff(computeDiff(it), logger)
                 }
+                it is KtfmtSkipped -> logger.i("Skipping for: ${it.input} because: ${it.reason}")
                 it is KtfmtFailure -> {
                     logger.e("Failed to analyse: ${it.input}")
                     it.message.split("\n").forEach { line -> logger.e("e: $line") }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
@@ -22,6 +22,7 @@ abstract class KtfmtFormatTask : KtfmtBaseTask() {
                     logger.i("Reformatting...: ${it.input}")
                     it.input.writeText(it.formattedCode, Charset.defaultCharset())
                 }
+                it is KtfmtSkipped -> logger.i("Skipping for: ${it.input} because: ${it.reason}")
                 it is KtfmtFailure -> {
                     logger.e("Failed to analyse: ${it.input}")
                     it.message.split("\n").forEach { line -> logger.e("e: $line") }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtResult.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtResult.kt
@@ -16,3 +16,5 @@ internal data class KtfmtFailure(
     val message: String,
     val reason: Throwable
 ) : KtfmtResult(input)
+
+internal data class KtfmtSkipped(override val input: File, val reason: String) : KtfmtResult(input)

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -174,6 +174,28 @@ internal class KtfmtCheckTaskIntegrationTest {
         assertThat(result.output).contains("Valid formatting for:")
     }
 
+    @Test
+    fun `check task skips a file if with --include-only`() {
+        val file1 = createTempFile(content = "val answer = `\n", fileName = "File1.kt")
+        val file2 = createTempFile(content = "val answer = 42\n", fileName = "File2.kt")
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments(
+                    "ktfmtCheckMain",
+                    "--info",
+                    "--include-only=${file2.relativeTo(tempDir)}"
+                )
+                .build()
+
+        assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
+        assertThat(result.output).contains("Skipping for:")
+        assertThat(result.output).contains("Not included inside --include-only")
+        assertThat(result.output).contains("Valid formatting for:")
+    }
+
     private fun createTempFile(
         @Language("kotlin") content: String,
         fileName: String = "TestFile.kt",

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
@@ -184,6 +184,29 @@ internal class KtfmtFormatTaskIntegrationTest {
         assertThat(result.output).contains("Reformatting...:")
     }
 
+    @Test
+    fun `format task skips a file if with --include-only`() {
+        val file1 = createTempFile(content = "val answer = `\n", fileName = "File1.kt")
+        val file2 = createTempFile(content = "val answer=42\n", fileName = "File2.kt")
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments(
+                    "ktfmtFormatMain",
+                    "--info",
+                    "--include-only=${file2.relativeTo(tempDir)}"
+                )
+                .build()
+
+        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
+        assertThat(result.output).contains("[ktfmt] Skipping for:")
+        assertThat(result.output).contains("Not included inside --include-only")
+        assertThat(result.output).contains("[ktfmt] Reformatting...")
+        assertThat(result.output).contains("[ktfmt] Successfully reformatted 1 files with Ktfmt")
+    }
+
     private fun createTempFile(
         @Language("kotlin") content: String,
         fileName: String = "TestFile.kt",


### PR DESCRIPTION
## 🚀 Description
I'm adding a `--include-only` flag that can be used to filter the Input only on desired files. The idea is to support scenarios like pre-commit hooks and similars.

A potential setup could look like:

```
tasks.register<KtfmtCheckTask>("ktfmtPrecommit") {
    source = project.fileTree(rootDir)
    include("**/*.kt")
}
```

And then the invocation would look like:

```
gw ktfmtPrecommit --include-only=/.../ktfmt-gradle/example/src/main/java/Sample2.kt
```

## 📄 Motivation and Context
Fixes #12 

## 🧪 How Has This Been Tested?
Integration & Unit tests are attached

## 📦 Types of changes
- [x] New feature (non-breaking change which adds functionality)