### PR TITLE
Improve error reporting for FormattingError

### DIFF
--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
@@ -63,16 +63,13 @@ abstract class KtfmtBaseTask : SourceTask() {
             val formattedCode = format(bean.toFormattingOptions(), originCode)
             val isCorrectlyFormatted = originCode == formattedCode
             KtfmtSuccess(input, isCorrectlyFormatted, formattedCode)
-        } catch (cause: Exception) {
+        } catch (cause: Throwable) {
             val message =
                 when (cause) {
-                    is IOException -> "Unable to read file: $input"
-                    is ParseError -> "Failed to parse file: $input"
-                    is FormattingError ->
-                        "Formatting error found in: $input\n".plus(
-                            cause.diagnostics().map { "$input:$it\n" }
-                        )
-                    else -> "Generic error while processing $input"
+                    is IOException -> "Unable to read file"
+                    is ParseError -> "Failed to parse file"
+                    is FormattingError -> cause.diagnostics().joinToString("\n") { "$input:$it" }
+                    else -> "Generic error during file processing"
                 }
             KtfmtFailure(input, message, cause)
         }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
@@ -15,7 +15,7 @@ abstract class KtfmtCheckTask : KtfmtBaseTask() {
 
     override suspend fun execute() {
         val result = processFileCollection(inputFiles)
-        result.forEach {
+        result.forEach { it ->
             when {
                 it is KtfmtSuccess && it.isCorrectlyFormatted ->
                     logger.i("Valid formatting for: ${it.input}")
@@ -23,8 +23,10 @@ abstract class KtfmtCheckTask : KtfmtBaseTask() {
                     logger.e("Invalid formatting for: ${it.input}")
                     printDiff(computeDiff(it), logger)
                 }
-                it is KtfmtFailure ->
-                    logger.e("Failing to format: ${it.input}\nError: ${it.message}", it.reason)
+                it is KtfmtFailure -> {
+                    logger.e("Failed to analyse: ${it.input}")
+                    it.message.split("\n").forEach { line -> logger.e("e: $line") }
+                }
             }
         }
 

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
@@ -22,8 +22,10 @@ abstract class KtfmtFormatTask : KtfmtBaseTask() {
                     logger.i("Reformatting...: ${it.input}")
                     it.input.writeText(it.formattedCode, Charset.defaultCharset())
                 }
-                it is KtfmtFailure ->
-                    logger.e("Failing to format: ${it.input}\nError: ${it.message}")
+                it is KtfmtFailure -> {
+                    logger.e("Failed to analyse: ${it.input}")
+                    it.message.split("\n").forEach { line -> logger.e("e: $line") }
+                }
             }
         }
 

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTaskTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTaskTest.kt
@@ -97,7 +97,7 @@ internal class KtfmtBaseTaskTest {
         val result = underTest.processFile(input) as KtfmtFailure
 
         assertThat(result.input).isEqualTo(input)
-        assertThat(result.message).isEqualTo("Failed to parse file: $input")
+        assertThat(result.message).isEqualTo("Failed to parse file")
         assertThat(result.reason).isInstanceOf(ParseError::class.java)
     }
 

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -32,7 +32,7 @@ internal class KtfmtCheckTaskIntegrationTest {
                 .buildAndFail()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(FAILED)
-        assertThat(result.output).contains("Error: Failed to parse file")
+        assertThat(result.output).contains("e: Failed to parse file")
     }
 
     @Test
@@ -47,6 +47,30 @@ internal class KtfmtCheckTaskIntegrationTest {
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(FAILED)
         assertThat(result.output).contains("[ktfmt] Invalid formatting")
+    }
+
+    @Test
+    fun `check task fails if ktfmt fails to process the code`() {
+        // The following code will case ktfmt to fail with error: did not generate token ";"
+        createTempFile(
+            """
+            val res = when {
+                true -> "1"; false -> "0"
+                else -> "-1"
+            }
+            """.trimIndent()
+        )
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain")
+                .buildAndFail()
+
+        assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(FAILED)
+        assertThat(result.output).contains("[ktfmt] Failed to analyse:")
+        assertThat(result.output).contains("TestFile.kt:2:18: error: did not generate token \";\"")
     }
 
     @Test
@@ -146,7 +170,7 @@ internal class KtfmtCheckTaskIntegrationTest {
                 .buildAndFail()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(FAILED)
-        assertThat(result.output).contains("Failed to parse file:")
+        assertThat(result.output).contains("Failed to parse file")
         assertThat(result.output).contains("Valid formatting for:")
     }
 

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
@@ -32,7 +32,7 @@ internal class KtfmtFormatTaskIntegrationTest {
                 .buildAndFail()
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(FAILED)
-        assertThat(result.output).contains("Error: Failed to parse file")
+        assertThat(result.output).contains("e: Failed to parse file")
     }
 
     @Test
@@ -180,7 +180,7 @@ internal class KtfmtFormatTaskIntegrationTest {
         // File 1 contains a parsing error and is untouched.
         assertThat(file1.readText()).isEqualTo("val answer = `")
         assertThat(file2.readText()).isEqualTo("val answer = 42\n")
-        assertThat(result.output).contains("Failing to format:")
+        assertThat(result.output).contains("Failed to analyse:")
         assertThat(result.output).contains("Reformatting...:")
     }
 


### PR DESCRIPTION
## 🚀 Description
Got a bug report from Slack: https://kotlinlang.slack.com/archives/C0BJ0GTE2/p1615839796241500?thread_ts=1615809255.232100&cid=C0BJ0GTE2

## 📄 Motivation and Context
Failures from `FormattingError` (coming from google-java-format) engine are not catched and will just let the tool fail.

## 🧪 How Has This Been Tested?
Attached JUnit test

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)