### PR TITLE
Bump Ktfmt to 0.22 and more

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,9 +3,9 @@ object Versions {
 }
 
 object BuildPluginsVersion {
-    const val DETEKT = "1.15.0"
+    const val DETEKT = "1.16.0"
     const val KOTLIN = "1.4.21"
-    const val VERSIONS_PLUGIN = "0.36.0"
+    const val VERSIONS_PLUGIN = "0.38.0"
 }
 
 object TestingLib {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -17,11 +17,18 @@ processors:
   active: true
   exclude:
     - 'DetektProgressListener'
+  # - 'KtFileCountProcessor'
+  # - 'PackageCountProcessor'
+  # - 'ClassCountProcessor'
   # - 'FunctionCountProcessor'
   # - 'PropertyCountProcessor'
-  # - 'ClassCountProcessor'
-  # - 'PackageCountProcessor'
-  # - 'KtFileCountProcessor'
+  # - 'ProjectComplexityProcessor'
+  # - 'ProjectCognitiveComplexityProcessor'
+  # - 'ProjectLLOCProcessor'
+  # - 'ProjectCLOCProcessor'
+  # - 'ProjectLOCProcessor'
+  # - 'ProjectSLOCProcessor'
+  # - 'LicenseHeaderLoaderExtension'
 
 console-reports:
   active: true
@@ -45,6 +52,7 @@ comments:
   AbsentOrWrongFileLicense:
     active: false
     licenseTemplateFile: 'license.template'
+    licenseTemplateIsRegex: false
   CommentOverPrivateFunction:
     active: false
   CommentOverPrivateProperty:
@@ -132,6 +140,8 @@ coroutines:
     active: false
   RedundantSuspendModifier:
     active: false
+  SleepInsteadOfDelay:
+    active: false
   SuspendFunWithFlowReturnType:
     active: false
 
@@ -173,22 +183,24 @@ empty-blocks:
 exceptions:
   active: true
   ExceptionRaisedInUnexpectedLocation:
-    active: false
+    active: true
     methodNames: [toString, hashCode, equals, finalize]
   InstanceOfCheckForException:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   NotImplementedDeclaration:
     active: false
+  ObjectExtendsThrowable:
+    active: false
   PrintStackTrace:
-    active: false
+    active: true
   RethrowCaughtException:
-    active: false
+    active: true
   ReturnFromFinally:
-    active: false
+    active: true
     ignoreLabeled: false
   SwallowedException:
-    active: false
+    active: true
     ignoredExceptionTypes:
      - InterruptedException
      - NumberFormatException
@@ -196,18 +208,18 @@ exceptions:
      - MalformedURLException
     allowedExceptionNameRegex: '_|(ignore|expected).*'
   ThrowingExceptionFromFinally:
-    active: false
+    active: true
   ThrowingExceptionInMain:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
-    active: false
+    active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     exceptions:
      - IllegalArgumentException
      - IllegalStateException
      - IOException
   ThrowingNewInstanceOfSameException:
-    active: false
+    active: true
   TooGenericExceptionCaught:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -317,6 +329,9 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
+  SpacingAroundAngleBrackets:
+    active: false
+    autoCorrect: true
   SpacingAroundColon:
     active: true
     autoCorrect: true
@@ -343,6 +358,9 @@ formatting:
     autoCorrect: true
   SpacingAroundRangeOperator:
     active: true
+    autoCorrect: true
+  SpacingAroundUnaryOperator:
+    active: false
     autoCorrect: true
   SpacingBetweenDeclarationsWithAnnotations:
     active: false
@@ -398,6 +416,7 @@ naming:
     ignoreOverridden: true
   InvalidPackageDeclaration:
     active: false
+    excludes: ['*.kts']
     rootPackage: ''
   MatchingDeclarationName:
     active: true
@@ -405,6 +424,8 @@ naming:
   MemberNameEqualsClassName:
     active: true
     ignoreOverridden: true
+  NoNameShadowing:
+    active: false
   NonBooleanPropertyPrefixedWithIs:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -455,7 +476,11 @@ performance:
 
 potential-bugs:
   active: true
+  CastToNullableType:
+    active: false
   Deprecation:
+    active: false
+  DontDowncastCollectionTypes:
     active: false
   DuplicateCaseInWhenExpression:
     active: true
@@ -463,6 +488,8 @@ potential-bugs:
     active: true
   EqualsWithHashCodeExist:
     active: true
+  ExitOutsideMain:
+    active: false
   ExplicitGarbageCollectionCall:
     active: true
   HasPlatformType:
@@ -472,7 +499,7 @@ potential-bugs:
     restrictToAnnotatedMethods: true
     returnValueAnnotations: ['*.CheckReturnValue', '*.CheckResult']
   ImplicitDefaultLocale:
-    active: false
+    active: true
   ImplicitUnitReturnType:
     active: false
     allowExplicitReturnType: true
@@ -499,14 +526,18 @@ potential-bugs:
   UnconditionalJumpStatementInLoop:
     active: false
   UnnecessaryNotNullOperator:
-    active: false
+    active: true
   UnnecessarySafeCall:
+    active: true
+  UnreachableCatchBlock:
     active: false
   UnreachableCode:
     active: true
   UnsafeCallOnNullableType:
     active: true
   UnsafeCast:
+    active: true
+  UnusedUnaryOperator:
     active: false
   UselessPostfixExpression:
     active: false
@@ -524,6 +555,9 @@ style:
     conversionFunctionPrefix: 'to'
   DataClassShouldBeImmutable:
     active: false
+  DestructuringDeclarationWithTooManyEntries:
+    active: false
+    maxDestructuringEntries: 3
   EqualsNullCall:
     active: true
   EqualsOnSignatureLine:
@@ -547,7 +581,8 @@ style:
     active: false
     methods: ['kotlin.io.println', 'kotlin.io.print']
   ForbiddenPublicDataClass:
-    active: false
+    active: true
+    excludes: ['**']
     ignorePackages: ['*.internal', '*.internal.*']
   ForbiddenVoid:
     active: false
@@ -556,12 +591,15 @@ style:
   FunctionOnlyReturningConstant:
     active: true
     ignoreOverridableFunction: true
+    ignoreActualFunction: true
     excludedFunctions: 'describeContents'
     excludeAnnotatedFunction: ['dagger.Provides']
   LibraryCodeMustSpecifyReturnType:
     active: true
+    excludes: ['**']
   LibraryEntitiesShouldNotBePublic:
-    active: false
+    active: true
+    excludes: ['**']
   LoopWithTooManyJumpStatements:
     active: true
     maxJumpCount: 1
@@ -578,6 +616,7 @@ style:
     ignoreNamedArgument: true
     ignoreEnums: false
     ignoreRanges: false
+    ignoreExtensionFunctions: true
   MandatoryBracesIfStatements:
     active: false
   MandatoryBracesLoops:
@@ -592,8 +631,10 @@ style:
     active: true
   ModifierOrder:
     active: true
-  NestedClassesVisibility:
+  MultilineLambdaItParameter:
     active: false
+  NestedClassesVisibility:
+    active: true
   NewLineAtEndOfFile:
     active: true
   NoTabs:
@@ -624,7 +665,7 @@ style:
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:
-    active: false
+    active: true
   SpacingBetweenPackageAndImports:
     active: false
   ThrowsCount:
@@ -641,6 +682,8 @@ style:
   UnnecessaryAnnotationUseSiteTarget:
     active: false
   UnnecessaryApply:
+    active: true
+  UnnecessaryFilter:
     active: false
   UnnecessaryInheritance:
     active: true
@@ -655,7 +698,7 @@ style:
   UnusedPrivateClass:
     active: true
   UnusedPrivateMember:
-    active: false
+    active: true
     allowedNames: '(_|ignored|expected|serialVersionUID)'
   UseArrayLiteralsInAnnotations:
     active: false
@@ -673,6 +716,10 @@ style:
     active: false
   UseIfInsteadOfWhen:
     active: false
+  UseIsNullOrEmpty:
+    active: false
+  UseOrEmpty:
+    active: false
   UseRequire:
     active: false
   UseRequireNotNull:
@@ -682,7 +729,7 @@ style:
   UtilityClassWithPublicConstructor:
     active: true
   VarCouldBeVal:
-    active: false
+    active: true
   WildcardImport:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -1,19 +1,19 @@
 object Versions {
-    const val AGP = "4.1.2"
-    const val COROUTINES = "1.4.2"
+    const val AGP = "4.1.3"
+    const val COROUTINES = "1.4.3"
     const val DIFF_UTIL = "4.9"
     const val JUPITER = "5.7.1"
-    const val KTFMT = "0.21"
+    const val KTFMT = "0.22"
     const val TRUTH = "1.1.2"
 }
 
 object BuildPluginsVersion {
-    const val BINARY_COMPATIBILITY_VALIDATOR = "0.4.0"
-    const val DETEKT = "1.15.0"
+    const val BINARY_COMPATIBILITY_VALIDATOR = "0.5.0"
+    const val DETEKT = "1.16.0"
     const val KOTLIN = "1.4.21"
     const val KTFMT = "0.4.0"
     const val PLUGIN_PUBLISH = "0.13.0"
-    const val VERSIONS_PLUGIN = "0.36.0"
+    const val VERSIONS_PLUGIN = "0.38.0"
 }
 
 object Libs {

--- a/plugin-build/gradle/wrapper/gradle-wrapper.properties
+++ b/plugin-build/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
@@ -67,4 +67,8 @@ internal data class FormattingOptionsBean(
                 GOOGLE -> KtfmtStyle.GOOGLE
             }
     }
+
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
 }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -50,13 +50,12 @@ internal class KtfmtCheckTaskIntegrationTest {
     }
 
     @Test
-    fun `check task fails if ktfmt fails to process the code`() {
-        // The following code will case ktfmt to fail with error: did not generate token ";"
+    fun `check task fails if ktfmt fails to parse the code`() {
+        // The following code will case ktfmt to fail with error: Failed to parse file
         createTempFile(
             """
             val res = when {
-                true -> "1"; false -> "0"
-                else -> "-1"
+                ````
             }
             """.trimIndent()
         )
@@ -70,7 +69,7 @@ internal class KtfmtCheckTaskIntegrationTest {
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(FAILED)
         assertThat(result.output).contains("[ktfmt] Failed to analyse:")
-        assertThat(result.output).contains("TestFile.kt:2:18: error: did not generate token \";\"")
+        assertThat(result.output).contains("e: Failed to parse file")
     }
 
     @Test


### PR DESCRIPTION
## 🚀 Description
Bumping the following deps:
- KtFmt to `0.22`
- Coroutines to `1.4.3`
- AGP to `4.1.3`
- Gradle to `6.8.3`

## 📦 Types of changes
- [x] New feature (non-breaking change which adds functionality)