### PR TITLE
Support Gradle 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+- Added support for Gradle 7.0
+- Added task ordering between `ktfmt*` tasks and `compileKotlin` tasks. This fix the correctness warning introduced with Gradle 7.0
+
+### Dependencies Update
+
+- Gradle to `7.0`
+
 ## Version 0.5.0 *(2021-03-20)*
 
 ### New features

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin-build/gradle/wrapper/gradle-wrapper.properties
+++ b/plugin-build/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -26,7 +26,6 @@ public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask : org/gradle/a
 	protected abstract fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getIncludeOnly ()Lorg/gradle/api/provider/Property;
 	protected final fun getInputFiles ()Lorg/gradle/api/file/FileCollection;
-	protected final fun getOutputFiles ()Lorg/gradle/api/file/FileCollection;
 }
 
 public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask : com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask {
@@ -37,5 +36,6 @@ public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask : com/ncorti/
 public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask : com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask {
 	public fun <init> ()V
 	protected fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun getOutputFiles ()Lorg/gradle/api/file/FileCollection;
 }
 

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
@@ -22,6 +22,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 private const val EXTENSION_NAME = "ktfmt"
 
@@ -110,6 +111,13 @@ abstract class KtfmtPlugin : Plugin<Project> {
     ) {
         val srcCheckTask = createCheckTask(project, ktfmtExtension, srcSetName, srcSetDir)
         val srcFormatTask = createFormatTask(project, ktfmtExtension, srcSetName, srcSetDir)
+
+        // When running together with compileKotlin, ktfmt tasks should have precedence as
+        // they're editing the source code
+        project.tasks.withType(KotlinCompile::class.java).all {
+            it.mustRunAfter(srcCheckTask, srcFormatTask)
+        }
+
         topLevelFormat.configure { task -> task.dependsOn(srcFormatTask) }
         topLevelCheck.configure { task -> task.dependsOn(srcCheckTask) }
 

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
@@ -21,7 +21,6 @@ import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceTask
@@ -53,10 +52,6 @@ abstract class KtfmtBaseTask : SourceTask() {
     @get:IgnoreEmptyDirectories
     protected val inputFiles: FileCollection
         get() = super.getSource()
-
-    @get:OutputFiles
-    protected val outputFiles: FileCollection
-        get() = inputFiles
 
     @TaskAction
     @VisibleForTesting

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
@@ -4,9 +4,15 @@ import com.ncorti.ktfmt.gradle.util.KtfmtUtils
 import com.ncorti.ktfmt.gradle.util.e
 import com.ncorti.ktfmt.gradle.util.i
 import java.nio.charset.Charset
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.OutputFiles
 
 /** ktfmt-gradle Format task. Replaces input file content with its formatted equivalent. */
 abstract class KtfmtFormatTask : KtfmtBaseTask() {
+
+    @get:OutputFiles
+    protected val outputFiles: FileCollection
+        get() = inputFiles
 
     init {
         group = KtfmtUtils.GROUP_FORMATTING

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
@@ -185,6 +185,22 @@ internal class KtfmtFormatTaskIntegrationTest {
     }
 
     @Test
+    fun `format task runs before compilation`() {
+        createTempFile(content = "val answer = 42\n")
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("compileKotlin", "ktfmtFormatMain")
+                .build()
+
+        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":compileKotlin")?.outcome).isEqualTo(SUCCESS)
+        assertThat(result.tasks.first().path).isEqualTo(":ktfmtFormatMain")
+        assertThat(result.tasks.last().path).isEqualTo(":compileKotlin")
+    }
+
+    @Test
     fun `format task skips a file if with --include-only`() {
         val file1 = createTempFile(content = "val answer = `\n", fileName = "File1.kt")
         val file2 = createTempFile(content = "val answer=42\n", fileName = "File2.kt")

--- a/plugin-build/plugin/src/test/resources/jvmProject/build.gradle.kts
+++ b/plugin-build/plugin/src/test/resources/jvmProject/build.gradle.kts
@@ -6,3 +6,7 @@ plugins {
 dependencies {
     implementation(kotlin("stdlib"))
 }
+
+repositories {
+    mavenCentral()
+}


### PR DESCRIPTION
## 🚀 Description
Bumps Gradle version to 7.0 and adds a task ordering rule between between `ktfmt*` tasks and `compileKotlin` tasks. This means that if you invoke `gradle compileKotlin ktfmtFormatTask`, ktfmt will run before the Kotlin compiler (as it's modifying the files).

## 📄 Motivation and Context
Fixes #24 

## 🧪 How Has This Been Tested?
Tests are attached.

## 📦 Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)