### PR TITLE
Make --include-only File separator invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+- `--include-only` now works with paths that are file-separator independent.
 - Added support for Gradle 7.0+
 - Added task ordering between `ktfmt*` tasks and `compileKotlin` tasks. This fix the correctness warning introduced with Gradle 7.0
 

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     `maven-publish`
     kotlin("jvm")
@@ -12,6 +14,10 @@ java {
 
 tasks.withType<PluginUnderTestMetadata>().configureEach {
     pluginClasspath.from(configurations.compileOnly)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
 }
 
 dependencies {


### PR DESCRIPTION
## 🚀 Description
This allows to specify paths with `--include-only` that are platform independent (either with `\` or `/`). 

## 📄 Motivation and Context
Fixes #22 
Closes #27 

## 🧪 How Has This Been Tested?
JUnit tests that are attached.

## 📦 Types of changes
- [x] New feature (non-breaking change which adds functionality)