### PR TITLE
KtFmt to 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please add your entries according to this format.
 ### Dependencies Update
 
 - Gradle to `7.0.2`
+- KtFmt to `0.24`
 
 ## Version 0.5.0 *(2021-03-20)*
 

--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val COROUTINES = "1.4.3"
     const val DIFF_UTIL = "4.9"
     const val JUPITER = "5.7.1"
-    const val KTFMT = "0.22"
+    const val KTFMT = "0.24"
     const val TRUTH = "1.1.2"
 }
 


### PR DESCRIPTION
## 🚀 Description
I'm bumping KtFmt to the latest stable before Kotlin 1.5.x