### PR TITLE
Fix markdown formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ source code like a glimpse.
 **ktfmt-gradle** is distributed through [Gradle Plugin Portal](https://plugins.gradle.org/). To use it you need to add
 the following dependency to your gradle files.
 
-Please note that those code needs to be added the gradle file of the **module** where you want to reformat the code (**
-not the top level** build.gradle[.kts] file).
+Please note that those code needs to be added the gradle file of the **module** where you want to reformat the code
+(**not the top level** build.gradle[.kts] file).
 
 If you're using the `plugin{}` blocks in your Gradle file:
 


### PR DESCRIPTION
## 🚀 Description
It's a really small thing, but some text wasn't being bolded in the readme because the starting asterisks were on a different line.

## 📄 Motivation and Context
This isn't strictly required, but it may look a little nicer than seeing the raw asterisks when first looking at the project.

## 🧪 How Has This Been Tested?
By viewing the rich diff Github provides [here](https://github.com/rsookram/ktfmt-gradle/commit/fd506c2df43c28d959a133cfec3a8cc672a8ce44?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

## 📦 Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

And this is a pretty great PR template :100: