### PR TITLE
Fix \n test failure on Windows

### DIFF
--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -118,9 +118,8 @@ internal class KtfmtCheckTaskIntegrationTest {
 
         assertThat(result.output).contains(":ktfmtCheckMain SKIPPED")
         assertThat(result.output).contains(":compileKotlin SKIPPED")
-        val lines = result.output.split("\n")
-        assertThat(lines.indexOf(":ktfmtCheckMain SKIPPED"))
-            .isLessThan(lines.indexOf(":compileKotlin SKIPPED"))
+        assertThat(result.output.indexOf(":ktfmtCheckMain SKIPPED"))
+            .isLessThan(result.output.indexOf(":compileKotlin SKIPPED"))
     }
 
     @Test

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
@@ -196,9 +196,8 @@ internal class KtfmtFormatTaskIntegrationTest {
 
         assertThat(result.output).contains(":ktfmtFormatMain SKIPPED")
         assertThat(result.output).contains(":compileKotlin SKIPPED")
-        val lines = result.output.split("\n")
-        assertThat(lines.indexOf(":ktfmtFormatMain SKIPPED"))
-            .isLessThan(lines.indexOf(":compileKotlin SKIPPED"))
+        assertThat(result.output.indexOf(":ktfmtCheckMain SKIPPED"))
+            .isLessThan(result.output.indexOf(":compileKotlin SKIPPED"))
     }
 
     @Test


### PR DESCRIPTION
There was a minor failure on Windows due to `\n`. I'm fixing it here.