### PR TITLE
Set Kotlin jvmTarget to 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+- Set Kotlin jvmTarget to 11
 - KtFmt to 0.32
 - Kotlin to 1.5.31
 - Gradle to 7.4

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     `kotlin-dsl`
     id("com.ncorti.ktfmt.gradle") version "0.7.0"
@@ -9,4 +11,7 @@ repositories {
 
 ktfmt {
     kotlinLangStyle()
+}
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
 }

--- a/plugin-build/buildSrc/build.gradle.kts
+++ b/plugin-build/buildSrc/build.gradle.kts
@@ -1,6 +1,11 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     `kotlin-dsl`
 }
 repositories {
     mavenCentral()
+}
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
 }

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 tasks.withType<PluginUnderTestMetadata>().configureEach {
@@ -19,7 +19,10 @@ tasks.withType<PluginUnderTestMetadata>().configureEach {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+    kotlinOptions {
+        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
+        jvmTarget = JavaVersion.VERSION_11.toString()
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## 🚀 Description
Due to google-java-format, Java 11 is a hard requirement.
This fixes the warning we're seeing such as:

```
'compileJava' task (current target is 11) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.
```

## 🧪 How Has This Been Tested?
Green locally, will rely on CI.

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)