### PR TITLE
Fix AGP's new Kotlin sourceset not being recognised by default

### DIFF
--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val AGP = "4.2.2"
+    const val AGP = "7.1.1"
     const val COROUTINES = "1.6.0"
     const val DIFF_UTIL = "4.9"
     const val JUPITER = "5.7.2"

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtAndroidUtils.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtAndroidUtils.kt
@@ -1,6 +1,7 @@
 package com.ncorti.ktfmt.gradle
 
 import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.internal.api.DefaultAndroidSourceDirectorySet
 import com.ncorti.ktfmt.gradle.KtfmtPluginUtils.createTasksForSourceSet
 import java.util.concurrent.Callable
 import org.gradle.api.Project
@@ -18,6 +19,10 @@ internal object KtfmtAndroidUtils {
         fun applyKtfmtForAndroid() {
             project.extensions.configure(BaseExtension::class.java) {
                 it.sourceSets.all { sourceSet ->
+                    val srcDirs = sourceSet.java.srcDirs + runCatching {
+                        // As sourceSet.kotlin doesn't exist before AGP 7
+                        (sourceSet.kotlin as? DefaultAndroidSourceDirectorySet)?.srcDirs
+                    }.getOrNull().orEmpty()
                     // Passing Callable, so returned FileCollection, will lazy evaluate it
                     // only when task will need it.
                     // Solves the problem of having additional source dirs in
@@ -26,7 +31,7 @@ internal object KtfmtAndroidUtils {
                     createTasksForSourceSet(
                         project,
                         sourceSet.name,
-                        project.files(Callable { sourceSet.java.srcDirs }),
+                        project.files(Callable { srcDirs }),
                         ktfmtExtension,
                         topLevelFormat,
                         topLevelCheck


### PR DESCRIPTION
Link detekt/detekt/pull/4554.