### PR TITLE
Add support for Configuration Cache

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -21,10 +21,8 @@
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/buildSrc" />
             <option value="$PROJECT_DIR$/example" />
             <option value="$PROJECT_DIR$/plugin-build" />
-            <option value="$PROJECT_DIR$/plugin-build/buildSrc" />
             <option value="$PROJECT_DIR$/plugin-build/plugin" />
           </set>
         </option>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+- Add support for Gradle Configuration Cache 
+- KtFmt to 0.40
+
 ## Version 0.9.0 *(2022-08-29)*
 
 - KtFmt to 0.39

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTaskTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTaskTest.kt
@@ -43,29 +43,6 @@ internal class KtfmtBaseTaskTest {
     }
 
     @Test
-    fun `scope is not canceled before running`() {
-        val project = ProjectBuilder.builder().build()
-        project.pluginManager.apply("org.jetbrains.kotlin.jvm")
-        project.pluginManager.apply("com.ncorti.ktfmt.gradle")
-
-        val underTest = project.tasks.getByName("ktfmtFormatMain") as KtfmtBaseTask
-
-        assertThat(underTest.isScopeActive()).isTrue()
-    }
-
-    @Test
-    fun `scope is canceled after running`() {
-        val project = ProjectBuilder.builder().build()
-        project.pluginManager.apply("org.jetbrains.kotlin.jvm")
-        project.pluginManager.apply("com.ncorti.ktfmt.gradle")
-
-        val underTest = project.tasks.getByName("ktfmtFormatMain") as KtfmtBaseTask
-        underTest.taskAction()
-
-        assertThat(underTest.isScopeActive()).isFalse()
-    }
-
-    @Test
     fun `processFile returns success for valid file`() {
         val underTest = project.tasks.getByName("ktfmtFormatMain") as KtfmtBaseTask
 

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -138,6 +138,25 @@ internal class KtfmtCheckTaskIntegrationTest {
     }
 
     @Test
+    fun `format task uses configuration cache correctly`() {
+        createTempFile(content = "val answer = 42\n")
+        GradleRunner.create()
+            .withProjectDir(tempDir)
+            .withPluginClasspath()
+            .withArguments("--configuration-cache", "ktfmtCheckMain")
+            .build()
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("--configuration-cache", "ktfmtCheckMain")
+                .build()
+
+        assertThat(result.output).contains("Reusing configuration cache.")
+    }
+
+    @Test
     fun `check task validates all the file with a failure`() {
         createTempFile(content = "val answer = `\n", fileName = "File1.kt")
         createTempFile(content = "val answer = 42\n", fileName = "File2.kt")

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
@@ -164,6 +164,25 @@ internal class KtfmtFormatTaskIntegrationTest {
     }
 
     @Test
+    fun `format task uses configuration cache correctly`() {
+        createTempFile(content = "val answer = 42\n")
+        GradleRunner.create()
+            .withProjectDir(tempDir)
+            .withPluginClasspath()
+            .withArguments("--configuration-cache", "ktfmtFormatMain")
+            .build()
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("--configuration-cache", "ktfmtFormatMain")
+                .build()
+
+        assertThat(result.output).contains("Reusing configuration cache.")
+    }
+
+    @Test
     fun `format task reformats all the file even with a failure`() {
         val file1 = createTempFile(content = "val answer = `", fileName = "File1.kt")
         val file2 = createTempFile(content = "val answer=42", fileName = "File2.kt")


### PR DESCRIPTION
## 🚀 Description
Remove references to Coroutine Scope so the tasks can properly work with Config. Cache from Gradle.

## 📄 Motivation and Context
Fixes #81

## 🧪 How Has This Been Tested?
Tested locally with `./gradlew :example:ktfmtCheck --configuration-cache`

## 📦 Types of changes
- [x] New feature (non-breaking change which adds functionality)