### PR TITLE
Add apiVersion & languageVersion to 1.4

### DIFF
--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -35,6 +35,8 @@ tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
         freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
         jvmTarget = JavaVersion.VERSION_11.toString()
+        apiVersion = "1.4"
+        languageVersion = "1.4"
     }
 }
 

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
@@ -2,7 +2,6 @@ package com.ncorti.ktfmt.gradle
 
 import com.ncorti.ktfmt.gradle.tasks.KtfmtCheckTask
 import com.ncorti.ktfmt.gradle.tasks.KtfmtFormatTask
-import java.util.Locale
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
@@ -54,9 +53,14 @@ internal object KtfmtPluginUtils {
     ): TaskProvider<KtfmtCheckTask> {
         val capitalizedName =
             name.split(" ").joinToString("") {
-                it.replaceFirstChar { char ->
-                    if (char.isLowerCase()) char.titlecase(Locale.getDefault()) else char.toString()
+                val charArray = it.toCharArray()
+                if (charArray[0].isLowerCase()) {
+                    // We use toUpperCase here to retain compatibility with Gradle 6.9 and Kotlin
+                    // 1.4
+                    @Suppress("DEPRECATION")
+                    charArray[0] = charArray[0].toUpperCase()
                 }
+                charArray.concatToString()
             }
         val taskName = "$TASK_NAME_CHECK$capitalizedName"
         return project.tasks.register(taskName, KtfmtCheckTask::class.java) {
@@ -77,9 +81,14 @@ internal object KtfmtPluginUtils {
     ): TaskProvider<KtfmtFormatTask> {
         val srcSetName =
             name.split(" ").joinToString("") {
-                it.replaceFirstChar { char ->
-                    if (char.isLowerCase()) char.titlecase(Locale.getDefault()) else char.toString()
+                val charArray = it.toCharArray()
+                if (charArray[0].isLowerCase()) {
+                    // We use toUpperCase here to retain compatibility with Gradle 6.9 and Kotlin
+                    // 1.4
+                    @Suppress("DEPRECATION")
+                    charArray[0] = charArray[0].toUpperCase()
                 }
+                charArray.concatToString()
             }
         val taskName = "$TASK_NAME_FORMAT$srcSetName"
         return project.tasks.register(taskName, KtfmtFormatTask::class.java) {

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
@@ -8,7 +8,7 @@ import com.ncorti.ktfmt.gradle.FormattingOptionsBean
 import com.ncorti.ktfmt.gradle.KtfmtExtension
 import java.io.File
 import java.io.IOException
-import kotlin.io.path.Path
+import java.nio.file.Paths
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -79,7 +79,10 @@ abstract class KtfmtBaseTask : SourceTask() {
                     .get()
                     .split(',', ':')
                     .map {
-                        Path("", *it.trim().split(File.separatorChar, '\\', '/').toTypedArray())
+                        Paths.get(
+                            "",
+                            *it.trim().split(File.separatorChar, '\\', '/').toTypedArray()
+                        )
                     }
                     .toSet()
             val relativePath = input.relativeTo(project.projectDir).toPath()


### PR DESCRIPTION
## 🚀 Description
Fixes #110

## 📄 Motivation and Context
This makes `ktfmt-gradle` easier to use on Gradle 6+

## 🧪 How Has This Been Tested?
Tested on a sample project on Gradle 6.9 + Unit testing.

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] My code follows the code style of this project.