### PR TITLE
Breaking: Prefix Multiplatform tasks with KMP

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,9 +5,4 @@
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="openjdk-16" project-jdk-type="JavaSDK" />
-  <component name="SwUserDefinedSpecifications">
-    <option name="specTypeByUrl">
-      <map />
-    </option>
-  </component>
 </project>

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
@@ -57,9 +57,10 @@ abstract class KtfmtPlugin : Plugin<Project> {
     private fun applyKtfmtToMultiplatformProject(project: Project) {
         val extension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
         extension.sourceSets.all {
+            val name = "kmp ${it.name}"
             createTasksForSourceSet(
                 project,
-                it.name,
+                name,
                 it.kotlin.sourceDirectories,
                 ktfmtExtension,
                 topLevelFormat,

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtPluginTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtPluginTest.kt
@@ -61,19 +61,19 @@ class KtfmtPluginTest {
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         project.pluginManager.apply("com.ncorti.ktfmt.gradle")
 
-        assertThat(project.tasks.getByName("ktfmtCheckCommonMain"))
+        assertThat(project.tasks.getByName("ktfmtCheckKmpCommonMain"))
             .isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatCommonMain"))
+        assertThat(project.tasks.getByName("ktfmtFormatKmpCommonMain"))
             .isInstanceOf(KtfmtFormatTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtCheckCommonTest"))
+        assertThat(project.tasks.getByName("ktfmtCheckKmpCommonTest"))
             .isInstanceOf(KtfmtCheckTask::class.java)
-        assertThat(project.tasks.getByName("ktfmtFormatCommonTest"))
+        assertThat(project.tasks.getByName("ktfmtFormatKmpCommonTest"))
             .isInstanceOf(KtfmtFormatTask::class.java)
 
         assertThat(project["ktfmtCheck"].dependencies)
-            .containsExactly("ktfmtCheckCommonMain", "ktfmtCheckCommonTest")
+            .containsExactly("ktfmtCheckKmpCommonMain", "ktfmtCheckKmpCommonTest")
         assertThat(project["ktfmtFormat"].dependencies)
-            .containsExactly("ktfmtFormatCommonMain", "ktfmtFormatCommonTest")
+            .containsExactly("ktfmtFormatKmpCommonMain", "ktfmtFormatKmpCommonTest")
     }
 
     @Suppress("LongMethod")


### PR DESCRIPTION
## 🚀 Description
I'm updating KMP tasks to be prefixed with `kmp` like `ktfmtFormatKmpCommonMain`.

## 📄 Motivation and Context
This will solve #121 and will help to decouple Android tasks from KMP tasks.
Fixes #121 
Closes #128

## 🧪 How Has This Been Tested?
Tests are attached.

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)