### PR TITLE
Do not create tasks for KSP sourcesets

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("jvm")
     id("com.ncorti.ktfmt.gradle")
+    id("com.google.devtools.ksp") version "1.9.0-1.0.11"
 }
 
 ktfmt {
@@ -11,6 +12,8 @@ dependencies {
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.jupiter)
     testRuntimeOnly(libs.jupiter.platform.launcher)
+    implementation("com.squareup.moshi:moshi-kotlin:1.14.0")
+    ksp("com.squareup.moshi:moshi-kotlin-codegen:1.14.0")
 }
 
 tasks.withType<Test> {

--- a/example/src/main/java/KspSample.kt
+++ b/example/src/main/java/KspSample.kt
@@ -1,0 +1,3 @@
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true) data class KspSample(val something: String)

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
@@ -17,6 +17,12 @@ internal object KtfmtPluginUtils {
 
     internal const val TASK_NAME_CHECK = "ktfmtCheck"
 
+    internal fun shouldCreateTasks(srcSetName: String): Boolean {
+        // KSP is adding new source sets called `generatedByKspKotlin`, `generatedByKspTestKotlin`
+        // For those source sets we don't want to run KSP as they're only generated code.
+        return !srcSetName.startsWith("generatedByKsp")
+    }
+
     @Suppress("LongParameterList")
     internal fun createTasksForSourceSet(
         project: Project,
@@ -26,6 +32,10 @@ internal object KtfmtPluginUtils {
         topLevelFormat: TaskProvider<Task>,
         topLevelCheck: TaskProvider<Task>
     ) {
+        if (shouldCreateTasks(srcSetName).not()) {
+            return
+        }
+
         val srcCheckTask = createCheckTask(project, ktfmtExtension, srcSetName, srcSetDir)
         val srcFormatTask = createFormatTask(project, ktfmtExtension, srcSetName, srcSetDir)
 

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/util/KtfmtPluginUtilsTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/util/KtfmtPluginUtilsTest.kt
@@ -1,0 +1,18 @@
+package com.ncorti.ktfmt.gradle.util
+
+import com.google.common.truth.Truth.assertThat
+import com.ncorti.ktfmt.gradle.KtfmtPluginUtils.shouldCreateTasks
+import org.junit.jupiter.api.Test
+
+class KtfmtPluginUtilsTest {
+
+    @Test
+    fun `shouldCreateTasks returns true for main sourceset`() {
+        assertThat(shouldCreateTasks("main")).isTrue()
+    }
+
+    @Test
+    fun `shouldCreateTasks returns false for KSP sourceset`() {
+        assertThat(shouldCreateTasks("generatedByKspKotlin")).isFalse()
+    }
+}


### PR DESCRIPTION
## 🚀 Description
Make sure ktfmt-gradle is not attempting to create tasks to format
code generated by KSP. As KSP creates source sets that are called `generatedByKsp...`
we don't want to create tasks for those sourcesets.

## 📄 Motivation and Context
Fixes #120

## 🧪 How Has This Been Tested?
Added a simple class to the `example` project

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

