### PR TITLE
Effectively exclude build/ folders from inspections

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm")
     id("com.ncorti.ktfmt.gradle")
     id("com.google.devtools.ksp") version "1.9.0-1.0.11"
+    id("app.cash.sqldelight") version "2.0.0-rc02"
 }
 
 ktfmt {
@@ -18,4 +19,12 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+sqldelight {
+  databases {
+    create("Database") {
+      packageName.set("com.example")
+    }
+  }
 }

--- a/example/src/main/sqldelight/com/example/sqldelight/hockey/data/Player.sq
+++ b/example/src/main/sqldelight/com/example/sqldelight/hockey/data/Player.sq
@@ -1,0 +1,9 @@
+CREATE TABLE hockeyPlayer (
+  player_number INTEGER PRIMARY KEY NOT NULL,
+  full_name TEXT NOT NULL
+);
+
+CREATE INDEX hockeyPlayer_full_name ON hockeyPlayer(full_name);
+
+INSERT INTO hockeyPlayer (player_number, full_name)
+VALUES (15, 'Ryan Getzlaf');

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -24,7 +24,6 @@ public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask : org/gradle/a
 	public fun <init> ()V
 	protected abstract fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getIncludeOnly ()Lorg/gradle/api/provider/Property;
-	protected final fun getInputFiles ()Lorg/gradle/api/file/FileCollection;
 }
 
 public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask : com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask {

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
@@ -91,7 +91,8 @@ abstract class KtfmtPlugin : Plugin<Project> {
     }
 
     companion object {
-        internal val defaultExcludes = listOf("build/")
+        internal val defaultExcludes = listOf("**/build/**")
+        internal val defaultExcludesRegex = Regex("^(.*[\\\\/])?build([\\\\/].*)?\$")
         internal val defaultIncludes = listOf("**/*.kt", "**/*.kts")
     }
 }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTaskTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTaskTest.kt
@@ -247,6 +247,35 @@ internal class KtfmtBaseTaskTest {
         assertThat((result[1] as KtfmtFailure).reason).isInstanceOf(ParseError::class.java)
     }
 
+    @Test
+    fun `regular files are not excluded`() {
+        val underTest = project.tasks.getByName("ktfmtFormatMain") as KtfmtBaseTask
+        val file = createTempFile(fileName = "file.kt", content = "")
+        underTest.source(file)
+
+        assertThat(underTest.inputFiles.files.contains(file)).isTrue()
+    }
+
+    @Test
+    fun `files in build folder are excluded`() {
+        val underTest = project.tasks.getByName("ktfmtFormatMain") as KtfmtBaseTask
+        val buildFile = createTempFile(fileName = "something/build/folder/file.kt", content = "")
+        underTest.source(buildFile)
+
+        assertThat(underTest.inputFiles.files.contains(buildFile)).isFalse()
+    }
+
+    @Test
+    fun `files in build folder are not excluded if users provided a custom exclude`() {
+        val underTest = project.tasks.getByName("ktfmtFormatMain") as KtfmtBaseTask
+        val buildFile = createTempFile(fileName = "something/build/folder/file.kt", content = "")
+        underTest.source(buildFile)
+
+        underTest.exclude("**/generated/**")
+
+        assertThat(underTest.inputFiles.files.contains(buildFile)).isTrue()
+    }
+
     private fun createTempFile(
         @Language("kotlin") content: String,
         fileName: String = "TestFile.kt",


### PR DESCRIPTION
## 🚀 Description
This fixes a problem where ktfmt-gradle would attempt to format files in the build folder. 
This happens as the exclude patterns are applied on **relative** paths. So when an external tool populates the `main` sourcesets, they include the following folder:

```
build/generated/sqldelight/code/Database/main/
```

so the exclude `**/build/**` pattern is not applied, as the relative path does not include `build/`.

To circumvent this, I'm applying a Regex matching against `build/` if the user hasn't manipulated the `exclude` property.

## 📄 Motivation and Context
Fixes #158

## 🧪 How Has This Been Tested?
Added SQLDelight example to repo

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
