### PR TITLE
Do not create tasks for aot srcset on Spring projects

### DIFF
--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
@@ -17,11 +17,15 @@ internal object KtfmtPluginUtils {
 
     internal const val TASK_NAME_CHECK = "ktfmtCheck"
 
-    internal fun shouldCreateTasks(srcSetName: String): Boolean {
-        // KSP is adding new source sets called `generatedByKspKotlin`, `generatedByKspTestKotlin`
-        // For those source sets we don't want to run KSP as they're only generated code.
-        return !srcSetName.startsWith("generatedByKsp")
-    }
+    internal fun shouldCreateTasks(srcSetName: String): Boolean =
+        when {
+            // KSP is adding new source sets called `generatedByKspKotlin`, `generatedByKspTestKotlin`
+            // For those source sets we don't want to run KSP as they're only generated code.
+            srcSetName.startsWith("generatedByKsp") -> false
+            // Spring is adding sourceSets called `aot` and `aotTest` which we don't want to inspect.
+            srcSetName == "aot" || srcSetName == "aotTest" -> false
+            else -> true
+        }
 
     @Suppress("LongParameterList")
     internal fun createTasksForSourceSet(

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
@@ -19,10 +19,12 @@ internal object KtfmtPluginUtils {
 
     internal fun shouldCreateTasks(srcSetName: String): Boolean =
         when {
-            // KSP is adding new source sets called `generatedByKspKotlin`, `generatedByKspTestKotlin`
+            // KSP is adding new source sets called `generatedByKspKotlin`,
+            // `generatedByKspTestKotlin`
             // For those source sets we don't want to run KSP as they're only generated code.
             srcSetName.startsWith("generatedByKsp") -> false
-            // Spring is adding sourceSets called `aot` and `aotTest` which we don't want to inspect.
+            // Spring is adding sourceSets called `aot` and `aotTest` which we don't want to
+            // inspect.
             srcSetName == "aot" || srcSetName == "aotTest" -> false
             else -> true
         }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/util/KtfmtPluginUtilsTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/util/KtfmtPluginUtilsTest.kt
@@ -15,4 +15,10 @@ class KtfmtPluginUtilsTest {
     fun `shouldCreateTasks returns false for KSP sourceset`() {
         assertThat(shouldCreateTasks("generatedByKspKotlin")).isFalse()
     }
+
+    @Test
+    fun `shouldCreateTasks returns false for Spring sourceset`() {
+        assertThat(shouldCreateTasks("aot")).isFalse()
+        assertThat(shouldCreateTasks("aotTest")).isFalse()
+    }
 }


### PR DESCRIPTION
## 🚀 Description
The Spring Boot gradle plugin configures `aot` and `aotTest` sourcesets that we should not inspect. I've added them as ignored srcsets to the the plugin config.

## 📄 Motivation and Context
Fixes #191

## 🧪 How Has This Been Tested?
Tested against `lukas-krecan/ktfmt-native` repro (cc @lukas-krecan)

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] My code follows the code style of this project.