### PR TITLE
Add configuration property to to select the gradle worker isolation strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Change Log
 
 This file follows [Keepachangelog](https://keepachangelog.com/) format.
@@ -6,9 +5,11 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+- Add configuration property to select Gradle worker isolation level (#205)
+
 ## Version 0.13.0 *(2023-10-09)*
 
-- Add support for Gradle Worker API and Classloader Isolation (#182)
+- Add support for Gradle Worker API and Classloader Isolation (#205)
 - KtFmt to 0.46
 - Kotlin to 1.9.10
 - Gradle to 8.4
@@ -35,12 +36,12 @@ Please add your entries according to this format.
 
 ## Version 0.11.0 *(2022-10-01)*
 
-- KtFmt to 0.41 
+- KtFmt to 0.41
 - AGP to 7.3.0
 
 ## Version 0.10.0 *(2022-09-09)*
 
-- Add support for Gradle Configuration Cache 
+- Add support for Gradle Configuration Cache
 - KtFmt to 0.40
 
 ## Version 0.9.0 *(2022-08-29)*
@@ -72,7 +73,8 @@ Please add your entries according to this format.
 
 - `--include-only` now works with paths that are file-separator independent.
 - Added support for Gradle 7.0+
-- Added task ordering between `ktfmt*` tasks and `compileKotlin` tasks. This fix the correctness warning introduced with Gradle 7.0
+- Added task ordering between `ktfmt*` tasks and `compileKotlin` tasks. This fix the correctness warning introduced with
+  Gradle 7.0
 
 ### Dependencies Update
 
@@ -98,7 +100,8 @@ Please add your entries according to this format.
 
 ### New features
 
-- Added the `kotlinLangStyle()` function to the `ktfmt{}` extension. This will allow you to apply a format that attempts to reflect the [official kotlin convetions](https://kotlinlang.org/docs/coding-conventions.html).
+- Added the `kotlinLangStyle()` function to the `ktfmt{}` extension. This will allow you to apply a format that attempts
+  to reflect the [official kotlin convetions](https://kotlinlang.org/docs/coding-conventions.html).
 
 ### Dependencies Update
 
@@ -122,7 +125,7 @@ Please add your entries according to this format.
 
 - Ktfmt to 0.19
 - Kotlin to 1.4.21
-- kotlinx-coroutines to 1.4.2 
+- kotlinx-coroutines to 1.4.2
 
 ## Version 0.1.0 *(2020-12-22)*
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ Please note that `ktfmt-gradle` relies on `ktfmt` hence the minimum supported JD
 
 Please also note the following requirements:
 
-* **Kotlin 1.4+**. In order to reformat Kotlin 1.4 code, you need run on **Gradle to 6.8+** (This is due to Gradle 6.7 embedding Kotlin 1.3.x - See [#12660](https://github.com/gradle/gradle/issues/12660)).
+* **Kotlin 1.4+**. In order to reformat Kotlin 1.4 code, you need run on **Gradle to 6.8+** (This is due to Gradle 6.7
+  embedding Kotlin 1.3.x - See [#12660](https://github.com/gradle/gradle/issues/12660)).
 
-* **Android**. `ktfmt-gradle` relies on features from **Android Gradle Plugin 4.1+**. So make sure you bump AGP before applying this plugin.
+* **Android**. `ktfmt-gradle` relies on features from **Android Gradle Plugin 4.1+**. So make sure you bump AGP before
+  applying this plugin.
 
 ### Task
 
@@ -91,10 +93,10 @@ To enable different styles you can simply:
 ktfmt {
     // Dropbox style - 4 space indentation
     dropboxStyle()
-    
+
     // Google style - 2 space indentation
     googleStyle()
-    
+
     // KotlinLang style - 4 space indentation - From kotlinlang.org/docs/coding-conventions.html
     kotlinLangStyle()
 }
@@ -115,11 +117,24 @@ ktfmt {
 }
 ```
 
+The Ktfmt formatter can be invoked from gradle with different dependency isolation strategies. By default, there is no
+isolation between ktfmt and other build dependencies. This should be sufficient for most projects. When you encounter
+errors related to dependency conflicts, you can try to invoke ktfmt in a separate process with its own classpath.
+
+```kotlin
+import com.ncorti.ktfmt.gradle.GradleWorkerIsolationStrategy
+
+ktfmt {
+    gradleWorkerIsolationStrategy.set(GradleWorkerIsolationStrategy.NO_ISOLATION)
+}
+```
+
 ## Using with a pre-commit hook 🎣
 
 You can leverage the `--include-only` to let ktfmt-gradle run only on a specific subset of files.
 
-To this you can register a simple task of type `KtfmtCheckTask` or `KtfmtFormatTask` in your `build.gradle.kts` as follows:
+To this you can register a simple task of type `KtfmtCheckTask` or `KtfmtFormatTask` in your `build.gradle.kts` as
+follows:
 
 ```kotlin
 import com.ncorti.ktfmt.gradle.tasks.*

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.ncorti.ktfmt.gradle.GradleWorkerIsolationStrategy
+
 plugins {
     kotlin("jvm")
     id("com.ncorti.ktfmt.gradle")
@@ -7,6 +9,7 @@ plugins {
 
 ktfmt {
     kotlinLangStyle()
+    gradleWorkerIsolationStrategy.set(GradleWorkerIsolationStrategy.NO_ISOLATION)
 }
 
 dependencies {

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/GradleWorkerIsolationStrategy.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/GradleWorkerIsolationStrategy.kt
@@ -1,0 +1,21 @@
+package com.ncorti.ktfmt.gradle
+
+import com.ncorti.ktfmt.gradle.GradleWorkerIsolationStrategy.*
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.workers.WorkQueue
+import org.gradle.workers.WorkerExecutor
+
+enum class GradleWorkerIsolationStrategy {
+    NO_ISOLATION,
+    PROCESS_ISOLATION
+}
+
+fun WorkerExecutor.getWorkQueue(
+    isolationStrategy: GradleWorkerIsolationStrategy,
+    classPath: ConfigurableFileCollection
+): WorkQueue {
+    return when (isolationStrategy) {
+        NO_ISOLATION -> this.noIsolation()
+        PROCESS_ISOLATION -> this.processIsolation { it.classpath.from(classPath) }
+    }
+}

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
@@ -14,6 +14,7 @@ abstract class KtfmtExtension {
         continuationIndent.convention(DEFAULT_CONTINUATION_INDENT)
         removeUnusedImports.convention(DEFAULT_REMOVE_UNUSED_IMPORTS)
         debuggingPrintOpsAfterFormatting.convention(DEFAULT_DEBUGGING_PRINT_OPTS)
+        gradleWorkerIsolationStrategy.convention(DEFAULT_GRADLE_WORKER_ISOLATION_STRATEGY)
     }
 
     internal var ktfmtStyle = FACEBOOK
@@ -53,6 +54,9 @@ abstract class KtfmtExtension {
      * newline) decisions
      */
     abstract val debuggingPrintOpsAfterFormatting: Property<Boolean>
+
+    /** Defines the isolation strategy between the ktfmt classpath and the project classpath. */
+    abstract val gradleWorkerIsolationStrategy: Property<GradleWorkerIsolationStrategy>
 
     /** Enables --dropbox-style (equivalent to set blockIndent to 4 and continuationIndent to 4). */
     @Suppress("MagicNumber")
@@ -97,5 +101,7 @@ abstract class KtfmtExtension {
         internal const val DEFAULT_CONTINUATION_INDENT: Int = 4
         internal const val DEFAULT_REMOVE_UNUSED_IMPORTS: Boolean = true
         internal const val DEFAULT_DEBUGGING_PRINT_OPTS: Boolean = false
+        internal val DEFAULT_GRADLE_WORKER_ISOLATION_STRATEGY: GradleWorkerIsolationStrategy =
+            GradleWorkerIsolationStrategy.NO_ISOLATION
     }
 }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
@@ -52,6 +52,7 @@ abstract class KtfmtPlugin : Plugin<Project> {
 
             project.tasks.withType(KtfmtBaseTask::class.java).configureEach {
                 it.ktfmtClasspath.from(ktFmt)
+                it.isolationStrategy.set(ktfmtExtension.gradleWorkerIsolationStrategy)
             }
 
             topLevelFormat = createTopLevelFormatTask(project)

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
@@ -1,8 +1,6 @@
 package com.ncorti.ktfmt.gradle.tasks
 
-import com.ncorti.ktfmt.gradle.FormattingOptionsBean
-import com.ncorti.ktfmt.gradle.KtfmtExtension
-import com.ncorti.ktfmt.gradle.KtfmtPlugin
+import com.ncorti.ktfmt.gradle.*
 import com.ncorti.ktfmt.gradle.tasks.worker.KtfmtWorkAction
 import com.ncorti.ktfmt.gradle.tasks.worker.Result
 import com.ncorti.ktfmt.gradle.util.d
@@ -56,14 +54,7 @@ internal constructor(
     @get:Input
     abstract val includeOnly: Property<String>
 
-    @get:Option(
-        option = "isolation-strategy",
-        description =
-            "Possible isolation strategies for invoking ktfmt. Can be PROCESS, CLASS_LOADER, NO_ISOLATION. Default is NO_ISOLATION"
-    )
-    @get:Optional
-    @get:Input
-    abstract val isolationStrategy: Property<String>
+    @get:Input abstract val isolationStrategy: Property<GradleWorkerIsolationStrategy>
 
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
@@ -73,28 +64,9 @@ internal constructor(
 
     @TaskAction
     internal fun taskAction() {
-        val workQueue = getWorkerQueue()
+        val workQueue = workerExecutor.getWorkQueue(isolationStrategy.get(), ktfmtClasspath)
 
-        val startTime = System.currentTimeMillis()
         execute(workQueue)
-        val endTime = System.currentTimeMillis()
-
-        logger.info("Worker queue finished after ${endTime-startTime} ms")
-    }
-
-    private fun getWorkerQueue(): WorkQueue {
-        val isolationStrategy = isolationStrategy.getOrElse("NO_ISOLATION")
-        logger.info("Selected workerQueue isolation strategy is $isolationStrategy")
-        return when (isolationStrategy) {
-            "PROCESS" ->
-                workerExecutor.processIsolation() { spec -> spec.classpath.from(ktfmtClasspath) }
-            "CLASS_LOADER" ->
-                workerExecutor.classLoaderIsolation() { spec ->
-                    spec.classpath.from(ktfmtClasspath)
-                }
-            "NO_ISOLATION" -> workerExecutor.noIsolation()
-            else -> workerExecutor.noIsolation()
-        }
     }
 
     protected abstract fun execute(workQueue: WorkQueue)

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -7,8 +7,11 @@ import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 internal class KtfmtCheckTaskIntegrationTest {
 
@@ -155,6 +158,60 @@ internal class KtfmtCheckTaskIntegrationTest {
                 .build()
 
         assertThat(result.output).contains("Reusing configuration cache.")
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
+    fun `format task can format multiple files using with default no-isolation workerQueue`(
+        n: Int
+    ) {
+        repeat(n) { index ->
+            createTempFile(content = "val answer${index}=42\n", fileName = "TestFile$index.kt")
+        }
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain", "--info")
+                .forwardOutput()
+                .build()
+
+        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
+    fun `format task can format multiple files using process isolation strategy`(n: Int) {
+        repeat(n) { index ->
+            createTempFile(content = "val answer${index}=42\n", fileName = "TestFile$index.kt")
+        }
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain", "--info", "--isolation-strategy=PROCESS")
+                .forwardOutput()
+                .build()
+
+        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
+    }
+
+    @Disabled("This test will never finish due to memory leasks in the class loader")
+    @ParameterizedTest
+    @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
+    fun `format task can format multiple files using class loader isolation strategy`(n: Int) {
+        repeat(n) { index ->
+            createTempFile(content = "val answer${index}=42\n", fileName = "TestFile$index.kt")
+        }
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain", "--info", "--isolation-strategy=CLASS_LOADER")
+                .forwardOutput()
+                .build()
+
+        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
     }
 
     @Test

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -162,56 +162,41 @@ internal class KtfmtCheckTaskIntegrationTest {
 
     @ParameterizedTest
     @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
-    fun `format task can format multiple files using with default no-isolation workerQueue`(
+    fun `check task can check the formatting of multiple files using with default no-isolation strategy`(
         n: Int
     ) {
         repeat(n) { index ->
-            createTempFile(content = "val answer${index}=42\n", fileName = "TestFile$index.kt")
+            createTempFile(content = "val answer${index} = 42\n", fileName = "TestFile$index.kt")
         }
         val result =
             GradleRunner.create()
                 .withProjectDir(tempDir)
                 .withPluginClasspath()
-                .withArguments("ktfmtFormatMain", "--info")
+                .withArguments("ktfmtCheckMain", "--info")
                 .forwardOutput()
                 .build()
 
-        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
     }
 
+    @Disabled("Extend test to use ktfmt property for isolation strategy")
     @ParameterizedTest
     @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
-    fun `format task can format multiple files using process isolation strategy`(n: Int) {
+    fun `check task can check the formatting of multiple files using process isolation strategy`(
+        n: Int
+    ) {
         repeat(n) { index ->
-            createTempFile(content = "val answer${index}=42\n", fileName = "TestFile$index.kt")
+            createTempFile(content = "val answer${index} = 42\n", fileName = "TestFile$index.kt")
         }
         val result =
             GradleRunner.create()
                 .withProjectDir(tempDir)
                 .withPluginClasspath()
-                .withArguments("ktfmtFormatMain", "--info", "--isolation-strategy=PROCESS")
+                .withArguments("ktfmtCheckMain", "--info", "--isolation-strategy=PROCESS")
                 .forwardOutput()
                 .build()
 
-        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
-    }
-
-    @Disabled("This test will never finish due to memory leasks in the class loader")
-    @ParameterizedTest
-    @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
-    fun `format task can format multiple files using class loader isolation strategy`(n: Int) {
-        repeat(n) { index ->
-            createTempFile(content = "val answer${index}=42\n", fileName = "TestFile$index.kt")
-        }
-        val result =
-            GradleRunner.create()
-                .withProjectDir(tempDir)
-                .withPluginClasspath()
-                .withArguments("ktfmtFormatMain", "--info", "--isolation-strategy=CLASS_LOADER")
-                .forwardOutput()
-                .build()
-
-        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
     }
 
     @Test

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -7,7 +7,6 @@ import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
@@ -179,12 +178,12 @@ internal class KtfmtCheckTaskIntegrationTest {
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
     }
 
-    @Disabled("Extend test to use ktfmt property for isolation strategy")
     @ParameterizedTest
     @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
     fun `check task can check the formatting of multiple files using process isolation strategy`(
         n: Int
     ) {
+        configureProcessIsolationStrategy()
         repeat(n) { index ->
             createTempFile(content = "val answer${index} = 42\n", fileName = "TestFile$index.kt")
         }
@@ -192,7 +191,7 @@ internal class KtfmtCheckTaskIntegrationTest {
             GradleRunner.create()
                 .withProjectDir(tempDir)
                 .withPluginClasspath()
-                .withArguments("ktfmtCheckMain", "--info", "--isolation-strategy=PROCESS")
+                .withArguments("ktfmtCheckMain", "--info")
                 .forwardOutput()
                 .build()
 
@@ -236,6 +235,11 @@ internal class KtfmtCheckTaskIntegrationTest {
         assertThat(result.output).contains("Skipping for:")
         assertThat(result.output).contains("Not included inside --include-only")
         assertThat(result.output).contains("Valid formatting for:")
+    }
+
+    private fun configureProcessIsolationStrategy() {
+        File("src/test/resources/jvmProjectProcessIsolation")
+            .copyRecursively(tempDir, overwrite = true)
     }
 
     private fun createTempFile(

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
@@ -8,8 +8,11 @@ import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 internal class KtfmtFormatTaskIntegrationTest {
 
@@ -180,6 +183,43 @@ internal class KtfmtFormatTaskIntegrationTest {
                 .build()
 
         assertThat(result.output).contains("Reusing configuration cache.")
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
+    fun `format task can format multiple files using with default no-isolation workerQueue`(
+        n: Int
+    ) {
+        repeat(n) { index ->
+            createTempFile(content = "val answer${index}=42\n", fileName = "TestFile$index.kt")
+        }
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain", "--info")
+                .forwardOutput()
+                .build()
+
+        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
+    }
+
+    @Disabled("Disabled because it is not yet possible to set the process strategy")
+    @ParameterizedTest
+    @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
+    fun `format task can format multiple files using process isolation strategy`(n: Int) {
+        repeat(n) { index ->
+            createTempFile(content = "val answer${index}=42\n", fileName = "TestFile$index.kt")
+        }
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain", "--info")
+                .forwardOutput()
+                .build()
+
+        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
     }
 
     @Test

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
@@ -8,7 +8,6 @@ import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
@@ -204,10 +203,10 @@ internal class KtfmtFormatTaskIntegrationTest {
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
     }
 
-    @Disabled("Disabled because it is not yet possible to set the process strategy")
     @ParameterizedTest
     @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
     fun `format task can format multiple files using process isolation strategy`(n: Int) {
+        configureProcessIsolationStrategy()
         repeat(n) { index ->
             createTempFile(content = "val answer${index}=42\n", fileName = "TestFile$index.kt")
         }
@@ -280,6 +279,11 @@ internal class KtfmtFormatTaskIntegrationTest {
         assertThat(result.output).contains("Not included inside --include-only")
         assertThat(result.output).contains("[ktfmt] Reformatting...")
         assertThat(result.output).contains("[ktfmt] Successfully reformatted 1 files with Ktfmt")
+    }
+
+    private fun configureProcessIsolationStrategy() {
+        File("src/test/resources/jvmProjectProcessIsolation")
+            .copyRecursively(tempDir, overwrite = true)
     }
 
     private fun createTempFile(

--- a/plugin-build/plugin/src/test/resources/jvmProjectProcessIsolation/build.gradle.kts
+++ b/plugin-build/plugin/src/test/resources/jvmProjectProcessIsolation/build.gradle.kts
@@ -1,0 +1,13 @@
+import com.ncorti.ktfmt.gradle.GradleWorkerIsolationStrategy
+
+plugins {
+    kotlin("jvm") version "1.7.20"
+    id("com.ncorti.ktfmt.gradle")
+}
+
+repositories { mavenCentral() }
+
+ktfmt {
+    kotlinLangStyle()
+    gradleWorkerIsolationStrategy.set(GradleWorkerIsolationStrategy.NO_ISOLATION)
+}

--- a/plugin-build/plugin/src/test/resources/jvmProjectProcessIsolation/settings.gradle.kts
+++ b/plugin-build/plugin/src/test/resources/jvmProjectProcessIsolation/settings.gradle.kts
@@ -1,0 +1,3 @@
+package jvmProjectProcessIsolation
+
+rootProject.name = ("test-fixtures")


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
As discussed in this , add a new property to select the isolation strategy for the gradle worker.


## 📄 Motivation and Context
Fixes [issue](https://github.com/cortinico/ktfmt-gradle/issues/203)

The user is able to select between the default no-isolation strategy and a process-isolation strategy. I remove the classloader-isolation strategy since it does not seem wo work for larger projects, and I wanted to prevent future issues ;)
But it could be easily added, if desired.

## 🧪 How Has This Been Tested?
Added integration tests for the format and checkFormat task.
The property is set in the example project.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.