### PR TITLE
Replace classloader isolation strategy with process isolation strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file follows [Keepachangelog](https://keepachangelog.com/) format.
 Please add your entries according to this format.
 
 ## Unreleased
+- Replace class loader isolation with process isolation (#206)
 
 ## Version 0.14.0 *(2023-10-09)*
 

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
@@ -28,10 +28,7 @@ import org.gradle.api.tasks.options.Option
 import org.gradle.workers.WorkQueue
 import org.gradle.workers.WorkerExecutor
 
-/**
- * ktfmt-gradle base Gradle tasks. Handles a coroutine scope and contains method to propertly
- * process a single file with ktfmt
- */
+/** ktfmt-gradle base Gradle tasks. Contains methods to properly process a single file with ktfmt */
 @Suppress("LeakingThis")
 abstract class KtfmtBaseTask
 internal constructor(
@@ -65,7 +62,7 @@ internal constructor(
     @TaskAction
     internal fun taskAction() {
         val workQueue =
-            workerExecutor.classLoaderIsolation { spec -> spec.classpath.from(ktfmtClasspath) }
+            workerExecutor.processIsolation { spec -> spec.classpath.from(ktfmtClasspath) }
         execute(workQueue)
     }
 

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -9,6 +9,8 @@ import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 internal class KtfmtCheckTaskIntegrationTest {
 
@@ -194,6 +196,23 @@ internal class KtfmtCheckTaskIntegrationTest {
         assertThat(result.output).contains("Skipping for:")
         assertThat(result.output).contains("Not included inside --include-only")
         assertThat(result.output).contains("Valid formatting for:")
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
+    fun `check task can check the formatting of multiple files`(n: Int) {
+        repeat(n) { index ->
+            createTempFile(content = "val answer${index} = 42\n", fileName = "TestFile$index.kt")
+        }
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain", "--info")
+                .forwardOutput()
+                .build()
+
+        assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
     }
 
     private fun createTempFile(

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
@@ -10,6 +10,8 @@ import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 internal class KtfmtFormatTaskIntegrationTest {
 
@@ -240,6 +242,23 @@ internal class KtfmtFormatTaskIntegrationTest {
         assertThat(result.output).contains("Not included inside --include-only")
         assertThat(result.output).contains("[ktfmt] Reformatting...")
         assertThat(result.output).contains("[ktfmt] Successfully reformatted 1 files with Ktfmt")
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [10, 15, 30, 50, 100, 1000])
+    fun `format task can format multiple files`(n: Int) {
+        repeat(n) { index ->
+            createTempFile(content = "val answer${index}=42\n", fileName = "TestFile$index.kt")
+        }
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtFormatMain", "--info")
+                .forwardOutput()
+                .build()
+
+        assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(SUCCESS)
     }
 
     private fun createTempFile(


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
Replace the class loader isolations strategy with the process isolation strategy to fix memory leaks in large projects

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix for this [issue](https://github.com/cortinico/ktfmt-gradle/issues/203) which is caused by this [issue](https://github.com/gradle/gradle/issues/18313)
With the current strategy large projects can not be formatted due to memory leaks.
Fixes https://github.com/cortinico/ktfmt-gradle/issues/203

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Added two new integration tests to verify that the ktfmtCheck and ktfmtFormat tasks work up to 1000 files as expected.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.