### PR TITLE
Create working dir if it's not existing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please add your entries according to this format.
 ## Unreleased
 
 - Remove legacy `kotlin-compiler-embeddable` dependency to prevent potential Kotlin version conflicts
+- Fix bug with Gradle Configuration Cache by always creating working dir if it's not existing
 - Kotlin to 1.9.21
 
 ## Version 0.15.1 *(2023-10-31)*

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/worker/KtfmtWorkAction.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/worker/KtfmtWorkAction.kt
@@ -63,7 +63,11 @@ internal abstract class KtfmtWorkAction : WorkAction<KtfmtWorkAction.KtfmtWorkPa
     }
 
     private fun writeResult(result: KtfmtResult) {
-        val resultFile = parameters.workingDir.asFile.get().resolve(UUID.randomUUID().toString())
+        val workingDir = parameters.workingDir.asFile.get()
+        if (!workingDir.exists()) {
+            workingDir.mkdirs()
+        }
+        val resultFile = workingDir.resolve(UUID.randomUUID().toString())
         resultFile.writeText(result.toResultString())
     }
 


### PR DESCRIPTION
## 🚀 Description
When used with configuration cache, ktfmt-gradle might end up in a scenario where the `/tmp` folder have been deleted and fails to run (see #219).
This fixes it by making sure that once the task executes, the `/tmp` folder are created if necessary.

## 📄 Motivation and Context
Fixes #219

## 🧪 How Has This Been Tested?
I've manually tested against the reproducer from #219

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)