### PR TITLE
Make `KtfmtCheckTask` task cacheable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+- Make `KtfmtCheckTask` cacheable
+
 ## Version 0.17.0 *(2024-01-31)*
 
 - KTFMT to 0.47

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -27,6 +27,7 @@ public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask : org/gradle/a
 
 public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask : com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask {
 	protected fun execute (Lorg/gradle/workers/WorkQueue;)V
+	public final fun getOutput ()Lorg/gradle/api/provider/Provider;
 }
 
 public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask : com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask {

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
@@ -7,14 +7,22 @@ import com.ncorti.ktfmt.gradle.util.d
 import com.ncorti.ktfmt.gradle.util.i
 import javax.inject.Inject
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.OutputFile
 import org.gradle.workers.WorkQueue
 import org.gradle.workers.WorkerExecutor
 
 /** ktfmt-gradle Check task. Verifies if the output of ktfmt is the same as the input */
+@CacheableTask
 abstract class KtfmtCheckTask
 @Inject
 internal constructor(workerExecutor: WorkerExecutor, layout: ProjectLayout) :
     KtfmtBaseTask(workerExecutor, layout) {
+
+    @get:OutputFile
+    val output: Provider<RegularFile> = layout.buildDirectory.file("ktfmt/output.txt")
 
     init {
         group = KtfmtUtils.GROUP_VERIFICATION
@@ -40,6 +48,8 @@ internal constructor(workerExecutor: WorkerExecutor, layout: ProjectLayout) :
             )
         }
 
-        logger.i("Successfully checked ${results.size} files with Ktfmt")
+        val message = "Successfully checked ${results.size} files with Ktfmt"
+        logger.i(message)
+        output.get().asFile.writeText(message)
     }
 }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -4,7 +4,9 @@ import com.google.common.truth.Truth.assertThat
 import java.io.File
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome.*
+import org.gradle.testkit.runner.TaskOutcome.FAILED
+import org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -1,10 +1,10 @@
 package com.ncorti.ktfmt.gradle.tasks
 
 import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.BuildResult
 import java.io.File
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome.FAILED
-import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.gradle.testkit.runner.TaskOutcome.*
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -78,28 +78,6 @@ internal class KtfmtCheckTaskIntegrationTest {
     fun `check task succeed if code is formatted`() {
         createTempFile(content = "val answer = 42\n")
         val result =
-            GradleRunner.create()
-                .withProjectDir(tempDir)
-                .withPluginClasspath()
-                .withArguments("ktfmtCheckMain")
-                .build()
-
-        assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
-    }
-
-    @Test
-    fun `check task is always executed on subsequent execution`() {
-        createTempFile(content = "val answer = 42\n")
-        var result =
-            GradleRunner.create()
-                .withProjectDir(tempDir)
-                .withPluginClasspath()
-                .withArguments("ktfmtCheckMain")
-                .build()
-
-        assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
-
-        result =
             GradleRunner.create()
                 .withProjectDir(tempDir)
                 .withPluginClasspath()
@@ -213,6 +191,38 @@ internal class KtfmtCheckTaskIntegrationTest {
                 .build()
 
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(SUCCESS)
+    }
+
+    @Test
+    fun `check task is cacheable`() {
+        createTempFile(content = "val answer = 42\n")
+
+        var result: BuildResult? = null
+        repeat(2) {
+            result = GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("clean", "ktfmtCheckMain", "--build-cache")
+                .build()
+        }
+
+        assertThat(result!!.task(":ktfmtCheckMain")?.outcome).isEqualTo(FROM_CACHE)
+    }
+
+    @Test
+    fun `check task is configuration cache compatible`() {
+        createTempFile(content = "val answer = 42\n")
+
+        var result: BuildResult? = null
+        repeat(2) {
+            result = GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheckMain", "--configuration-cache")
+                .build()
+        }
+
+        assertThat(result!!.output).contains("Reusing configuration cache.")
     }
 
     private fun createTempFile(

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -1,8 +1,8 @@
 package com.ncorti.ktfmt.gradle.tasks
 
 import com.google.common.truth.Truth.assertThat
-import org.gradle.testkit.runner.BuildResult
 import java.io.File
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.*
 import org.intellij.lang.annotations.Language
@@ -199,11 +199,12 @@ internal class KtfmtCheckTaskIntegrationTest {
 
         var result: BuildResult? = null
         repeat(2) {
-            result = GradleRunner.create()
-                .withProjectDir(tempDir)
-                .withPluginClasspath()
-                .withArguments("clean", "ktfmtCheckMain", "--build-cache")
-                .build()
+            result =
+                GradleRunner.create()
+                    .withProjectDir(tempDir)
+                    .withPluginClasspath()
+                    .withArguments("clean", "ktfmtCheckMain", "--build-cache")
+                    .build()
         }
 
         assertThat(result!!.task(":ktfmtCheckMain")?.outcome).isEqualTo(FROM_CACHE)
@@ -215,11 +216,12 @@ internal class KtfmtCheckTaskIntegrationTest {
 
         var result: BuildResult? = null
         repeat(2) {
-            result = GradleRunner.create()
-                .withProjectDir(tempDir)
-                .withPluginClasspath()
-                .withArguments("ktfmtCheckMain", "--configuration-cache")
-                .build()
+            result =
+                GradleRunner.create()
+                    .withProjectDir(tempDir)
+                    .withPluginClasspath()
+                    .withArguments("ktfmtCheckMain", "--configuration-cache")
+                    .build()
         }
 
         assertThat(result!!.output).contains("Reusing configuration cache.")


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
This change makes `KtfmtCheckTask` cacheable.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`KtfmtCheckTask` should be cacheable. It does not make sense to check again the same files.

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I added two tests and removed one.
Here's the Build Scan from my local build: https://scans.gradle.com/s/pgyogose35nba/tests/overview

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.