### PR TITLE
Fix inconsistency related to `--include-only` param in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ tasks.register<KtfmtFormatTask>("ktfmtPrecommit") {
 }
 ```
 
-You can then invoke the task with `--include-only` and a comma separated list of relative path of files:
+You can then invoke the task with `--include-only` and a comma-separated (or colon-separated) list of relative path of files:
 
 ```
 ./gradlew ktfmtPrecommit --include-only=src/main/java/File1.kt:src/main/java/File2.kt


### PR DESCRIPTION
## 🚀 Description
There is an inconsistency in the readme for `--include-only` param where it says `comma separated values`, but in the example, there are colon-separated values. Somebody else raised it also [in slack](https://slack-chats.kotlinlang.org/t/15988702/why-does-ktfmt-change-the-formatting-of-this-kdoc-lifecycle-#e706b14f-9df4-4a69-a24b-f5c7ae518fbf).

## 📄 Motivation and Context
- improves clarity of the docs

## 🧪 How Has This Been Tested?
- I didn't test this but I checked the source code and it supports both: https://github.com/cortinico/ktfmt-`gradle/blob/ecda8fb1ca3e1414f2337ae2de97340425cbc7f1/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/IncludedFilesParser.kt#L9

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.