### PR TITLE
Fix task caching for ktfmtCheck task with multiple sourceSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+- Fix task caching for ktfmtCheckTask when project has multiple source sets (#288)
+
 ## Version 0.18.0 _(2024-04-13)_
 
 - Make `KtfmtCheckTask` cacheable

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
@@ -22,7 +22,7 @@ internal constructor(workerExecutor: WorkerExecutor, layout: ProjectLayout) :
     KtfmtBaseTask(workerExecutor, layout) {
 
     @get:OutputFile
-    val output: Provider<RegularFile> = layout.buildDirectory.file("ktfmt/output.txt")
+    val output: Provider<RegularFile> = layout.buildDirectory.file("ktfmt/${this.name}/output.txt")
 
     init {
         group = KtfmtUtils.GROUP_VERIFICATION


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->

- Add a test to check if the task caching works for ktfmtCheck task with multiple different sourceSets (If both contain the same amount if files, the file is identical and therefore the task caching works)
- Append the task name to the outputFile. This seems to be easier then the sourceSet name, because the sourceSet name would have to be passed in in the ktfmtBaseTask.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/cortinico/ktfmt-gradle/issues/288

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
An integration test was added. Before the changes, the test fails.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

If you see the outputFile as part of the public API, then this would be a breaking change. I am not aware of a real usecase for the file.

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.