### PR TITLE
#317 remove usage of internal / deprecated method calls in preparatio for gradle 8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+- Update formatting of `build.gradle.kts` with ktfmt 0.51
+- Replace deprecated methods in `build.gradle.kts` files
+- Prepare for Gradle 8.9
+
 ## Version 0.19.0 _(2024-07-03)_
 
 - Remove dropboxStyle since it is no longer supported by ktfmt. Use kotlinLangStyle() instead
@@ -113,7 +117,8 @@ Please add your entries according to this format.
 
 - `--include-only` now works with paths that are file-separator independent.
 - Added support for Gradle 7.0+
-- Added task ordering between `ktfmt*` tasks and `compileKotlin` tasks. This fix the correctness warning introduced with Gradle 7.0
+- Added task ordering between `ktfmt*` tasks and `compileKotlin` tasks. This fix the correctness warning introduced with
+  Gradle 7.0
 
 ### Dependencies Update
 
@@ -139,7 +144,8 @@ Please add your entries according to this format.
 
 ### New features
 
-- Added the `kotlinLangStyle()` function to the `ktfmt{}` extension. This will allow you to apply a format that attempts to reflect the [official kotlin convetions](https://kotlinlang.org/docs/coding-conventions.html).
+- Added the `kotlinLangStyle()` function to the `ktfmt{}` extension. This will allow you to apply a format that attempts
+  to reflect the [official kotlin convetions](https://kotlinlang.org/docs/coding-conventions.html).
 
 ### Dependencies Update
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,26 +9,16 @@ plugins {
 }
 
 subprojects {
-    apply {
-        plugin(rootProject.libs.plugins.detekt.get().pluginId)
-    }
+    apply { plugin(rootProject.libs.plugins.detekt.get().pluginId) }
 
-    detekt {
-        config.setFrom(rootProject.files("config/detekt/detekt.yml"))
-    }
+    detekt { config.setFrom(rootProject.files("config/detekt/detekt.yml")) }
 }
 
-tasks.withType<DependencyUpdatesTask> {
-    rejectVersionIf {
-        isNonStable(candidate.version)
-    }
-}
+tasks.withType<DependencyUpdatesTask> { rejectVersionIf { isNonStable(candidate.version) } }
 
 fun isNonStable(version: String) = "^[0-9,.v-]+(-r)?$".toRegex().matches(version).not()
 
-tasks.register("clean", Delete::class.java) {
-    delete(rootProject.buildDir)
-}
+tasks.register("clean", Delete::class.java) { delete(rootProject.buildDir) }
 
 tasks.register("reformatAll") {
     description = "Reformat all the Kotlin Code"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.withType<DependencyUpdatesTask> { rejectVersionIf { isNonStable(candidate.
 
 fun isNonStable(version: String) = "^[0-9,.v-]+(-r)?$".toRegex().matches(version).not()
 
-tasks.register("clean", Delete::class.java) { delete(rootProject.buildDir) }
+tasks.register<Delete>("clean") { delete(layout.buildDirectory) }
 
 tasks.register("reformatAll") {
     description = "Reformat all the Kotlin Code"

--- a/example-kmp/build.gradle.kts
+++ b/example-kmp/build.gradle.kts
@@ -10,18 +10,14 @@ kotlin {
     androidTarget()
 }
 
-ktfmt {
-    kotlinLangStyle()
-}
+ktfmt { kotlinLangStyle() }
 
 android {
     namespace = "com.ncorti.example.ktfmt"
     compileSdk = 33
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
+tasks.withType<Test> { useJUnitPlatform() }
 
 dependencies {
     testImplementation(platform(libs.junit.bom))

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -5,13 +5,9 @@ plugins {
     id("app.cash.sqldelight") version "2.0.2"
 }
 
-ktfmt {
-    kotlinLangStyle()
-}
+ktfmt { kotlinLangStyle() }
 
-kotlin {
-    jvmToolchain(17)
-}
+kotlin { jvmToolchain(17) }
 
 dependencies {
     testImplementation(platform(libs.junit.bom))
@@ -21,14 +17,6 @@ dependencies {
     ksp("com.squareup.moshi:moshi-kotlin-codegen:1.15.1")
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
+tasks.withType<Test> { useJUnitPlatform() }
 
-sqldelight {
-  databases {
-    create("Database") {
-      packageName.set("com.example")
-    }
-  }
-}
+sqldelight { databases { create("Database") { packageName.set("com.example") } } }

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -18,23 +18,13 @@ allprojects {
         plugin(rootProject.libs.plugins.ktfmt.get().pluginId)
     }
 
-    ktfmt {
-        kotlinLangStyle()
-    }
+    ktfmt { kotlinLangStyle() }
 
-    detekt {
-        config.setFrom(rootProject.files("../config/detekt/detekt.yml"))
-    }
+    detekt { config.setFrom(rootProject.files("../config/detekt/detekt.yml")) }
 }
 
-tasks.withType<DependencyUpdatesTask> {
-    rejectVersionIf {
-        isNonStable(candidate.version)
-    }
-}
+tasks.withType<DependencyUpdatesTask> { rejectVersionIf { isNonStable(candidate.version) } }
 
 fun isNonStable(version: String) = "^[0-9,.v-]+(-r)?$".toRegex().matches(version).not()
 
-tasks.register("clean", Delete::class.java) {
-    delete(rootProject.buildDir)
-}
+tasks.register("clean", Delete::class.java) { delete(rootProject.buildDir) }

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -27,4 +27,4 @@ tasks.withType<DependencyUpdatesTask> { rejectVersionIf { isNonStable(candidate.
 
 fun isNonStable(version: String) = "^[0-9,.v-]+(-r)?$".toRegex().matches(version).not()
 
-tasks.register("clean", Delete::class.java) { delete(rootProject.buildDir) }
+tasks.register<Delete>("clean") { delete(layout.buildDirectory) }

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
                 .first()))
 }
 
+@Suppress("UnstableApiUsage")
 gradlePlugin {
     plugins {
         create(property("ID").toString()) {
@@ -77,12 +78,12 @@ gradlePlugin {
             version = property("VERSION").toString()
             displayName = property("DISPLAY_NAME").toString()
             description = property("DESCRIPTION").toString()
-            tags.set(listOf("ktfmt", "kotlin", "formatter", "reformat", "style", "code", "linter"))
+            tags = listOf("ktfmt", "kotlin", "formatter", "reformat", "style", "code", "linter")
         }
     }
 
-    website.set(property("WEBSITE").toString())
-    vcsUrl.set(property("VCS_URL").toString())
+    website = property("WEBSITE").toString()
+    vcsUrl = property("VCS_URL").toString()
 }
 
 signing {
@@ -95,7 +96,7 @@ tasks.withType<Sign>().configureEach { onlyIf { project.properties["skip-signing
 
 tasks.withType<Test> { useJUnitPlatform() }
 
-val persistKtmftVersion by
+val persistKtfmtVersion by
     tasks.registering {
         inputs.property("ktfmtVersion", libs.ktfmt)
         outputs.files(layout.buildDirectory.file("ktfmt-version.txt"))
@@ -103,5 +104,5 @@ val persistKtmftVersion by
     }
 
 tasks.named<ProcessResources>("processResources") {
-    from(persistKtmftVersion) { into("com/ncorti/ktfmt/gradle") }
+    from(persistKtfmtVersion) { into("com/ncorti/ktfmt/gradle") }
 }

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.api.internal.classpath.ModuleRegistry
-import org.gradle.configurationcache.extensions.serviceOf
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
@@ -58,14 +56,6 @@ dependencies {
     testImplementation(libs.truth)
 
     testImplementation(libs.ktfmt)
-
-    testRuntimeOnly(
-        files(
-            serviceOf<ModuleRegistry>()
-                .getModule("gradle-tooling-api-builders")
-                .classpath
-                .asFiles
-                .first()))
 }
 
 @Suppress("UnstableApiUsage")

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.api.internal.classpath.ModuleRegistry
 import org.gradle.configurationcache.extensions.serviceOf
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     kotlin("jvm")
@@ -14,7 +15,14 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
-tasks.withType<KotlinCompile> { kotlinOptions { jvmTarget = JavaVersion.VERSION_11.toString() } }
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+        apiVersion.set(KotlinVersion.fromVersion("1.4"))
+        languageVersion.set(KotlinVersion.fromVersion("1.4"))
+        jvmTarget = JvmTarget.JVM_11
+    }
+}
 
 /**
  * We create a configuration that we can resolve by extending [compileOnly]. Here we inject the
@@ -33,15 +41,6 @@ integrationTestRuntime.apply {
 
 tasks.withType<PluginUnderTestMetadata>().configureEach {
     pluginClasspath.from(integrationTestRuntime)
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
-        jvmTarget = JavaVersion.VERSION_11.toString()
-        apiVersion = "1.4"
-        languageVersion = "1.4"
-    }
 }
 
 dependencies {

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -17,7 +17,6 @@ java {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
         apiVersion.set(KotlinVersion.fromVersion("1.4"))
         languageVersion.set(KotlinVersion.fromVersion("1.4"))
         jvmTarget = JvmTarget.JVM_11

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -14,18 +14,15 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
-    }
-}
+tasks.withType<KotlinCompile> { kotlinOptions { jvmTarget = JavaVersion.VERSION_11.toString() } }
 
 /**
- * We create a configuration that we can resolve by extending [compileOnly].
- * Here we inject the dependencies into TestKit plugin
- * classpath via [PluginUnderTestMetadata] to make them available for testing.
+ * We create a configuration that we can resolve by extending [compileOnly]. Here we inject the
+ * dependencies into TestKit plugin classpath via [PluginUnderTestMetadata] to make them available
+ * for testing.
  */
 val integrationTestRuntime: Configuration by configurations.creating
+
 integrationTestRuntime.apply {
     extendsFrom(configurations.getByName("compileOnly"))
     attributes {
@@ -66,10 +63,11 @@ dependencies {
 
     testRuntimeOnly(
         files(
-            serviceOf<ModuleRegistry>().getModule("gradle-tooling-api-builders")
-                .classpath.asFiles.first()
-        )
-    )
+            serviceOf<ModuleRegistry>()
+                .getModule("gradle-tooling-api-builders")
+                .classpath
+                .asFiles
+                .first()))
 }
 
 gradlePlugin {
@@ -96,20 +94,15 @@ signing {
 
 tasks.withType<Sign>().configureEach { onlyIf { project.properties["skip-signing"] != "true" } }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
+tasks.withType<Test> { useJUnitPlatform() }
 
-val persistKtmftVersion by tasks.registering {
-    inputs.property("ktfmtVersion", libs.ktfmt)
-    outputs.files(layout.buildDirectory.file("ktfmt-version.txt"))
-    doLast {
-        outputs.files.singleFile.writeText(inputs.properties["ktfmtVersion"].toString())
+val persistKtmftVersion by
+    tasks.registering {
+        inputs.property("ktfmtVersion", libs.ktfmt)
+        outputs.files(layout.buildDirectory.file("ktfmt-version.txt"))
+        doLast { outputs.files.singleFile.writeText(inputs.properties["ktfmtVersion"].toString()) }
     }
-}
 
 tasks.named<ProcessResources>("processResources") {
-    from(persistKtmftVersion) {
-        into("com/ncorti/ktfmt/gradle")
-    }
+    from(persistKtmftVersion) { into("com/ncorti/ktfmt/gradle") }
 }

--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -11,11 +11,7 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 
-    versionCatalogs {
-        create("libs") {
-            from(files("../gradle/libs.versions.toml"))
-        }
-    }
+    versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
 }
 
 rootProject.name = ("com.ncorti.ktfmt.gradle")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,4 +19,7 @@ include(
     ":example",
     ":example-kmp",
 )
-includeBuild("plugin-build")
+
+includeBuild(
+    "plugin-build",
+)


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
This PR does
- formats the build gradle files with the latest ktfmt version
- remove the deprecations in the build gradle files
- Remove testRuntimeOnly dependency in preparation for gradle 8.9

After this PR is merged, it should be possible to merge this [PR](https://github.com/cortinico/ktfmt-gradle/pull/314) and update gradle to 8.9

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The formatting was done, because editing the build gradle files makes using the auto formatter hard, since they are not compliant with the current format.

The deprecations were removed, since they will be removed in the future.

The testRuntime dependency is removed, because it prevents the update to gradle 8.9

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Integration tests are still working

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.