### PR TITLE
#292 ktfmt does not use custom source directories

### DIFF
--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
@@ -77,7 +77,7 @@ abstract class KtfmtPlugin : Plugin<Project> {
             createTasksForSourceSet(
                 project,
                 it.name,
-                it.kotlin.sourceDirectories,
+                project.provider { it.kotlin.sourceDirectories },
                 ktfmtExtension,
                 topLevelFormat,
                 topLevelCheck)
@@ -96,7 +96,7 @@ abstract class KtfmtPlugin : Plugin<Project> {
             createTasksForSourceSet(
                 project,
                 name,
-                it.kotlin.sourceDirectories,
+                project.provider { it.kotlin.sourceDirectories },
                 ktfmtExtension,
                 topLevelFormat,
                 topLevelCheck,

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
@@ -5,6 +5,7 @@ import com.ncorti.ktfmt.gradle.tasks.KtfmtFormatTask
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -33,7 +34,7 @@ internal object KtfmtPluginUtils {
     internal fun createTasksForSourceSet(
         project: Project,
         srcSetName: String,
-        srcSetDir: FileCollection,
+        srcSetDir: Provider<FileCollection>,
         ktfmtExtension: KtfmtExtension,
         topLevelFormat: TaskProvider<Task>,
         topLevelCheck: TaskProvider<Task>
@@ -65,7 +66,7 @@ internal object KtfmtPluginUtils {
         project: Project,
         ktfmtExtension: KtfmtExtension,
         name: String,
-        srcDir: FileCollection
+        srcDir: Provider<FileCollection>
     ): TaskProvider<KtfmtCheckTask> {
         val capitalizedName =
             name.split(" ").joinToString("") {
@@ -79,11 +80,10 @@ internal object KtfmtPluginUtils {
                 charArray.concatToString()
             }
         val taskName = "$TASK_NAME_CHECK$capitalizedName"
-        val inputDirs = srcDir.toList()
         return project.tasks.register(taskName, KtfmtCheckTask::class.java) {
             it.description =
                 "Run Ktfmt formatter for sourceSet '$name' on project '${project.name}'"
-            it.setSource(inputDirs)
+            it.setSource(srcDir)
             it.setIncludes(KtfmtPlugin.defaultIncludes)
             it.setExcludes(KtfmtPlugin.defaultExcludes)
             it.bean = ktfmtExtension.toBean()
@@ -94,7 +94,7 @@ internal object KtfmtPluginUtils {
         project: Project,
         ktfmtExtension: KtfmtExtension,
         name: String,
-        srcDir: FileCollection
+        srcDir: Provider<FileCollection>
     ): TaskProvider<KtfmtFormatTask> {
         val srcSetName =
             name.split(" ").joinToString("") {
@@ -108,11 +108,10 @@ internal object KtfmtPluginUtils {
                 charArray.concatToString()
             }
         val taskName = "$TASK_NAME_FORMAT$srcSetName"
-        val inputDirs = srcDir.toList()
         return project.tasks.register(taskName, KtfmtFormatTask::class.java) {
             it.description =
                 "Run Ktfmt formatter validation for sourceSet '$name' on project '${project.name}'"
-            it.setSource(inputDirs)
+            it.setSource(srcDir)
             it.setIncludes(KtfmtPlugin.defaultIncludes)
             it.setExcludes(KtfmtPlugin.defaultExcludes)
             it.bean = ktfmtExtension.toBean()

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -258,7 +258,8 @@ internal class KtfmtCheckTaskIntegrationTest {
 
     @Test
     fun `check task should detect the source and test files in a flattened project structure`() {
-        appendToBuildGradle("""
+        appendToBuildGradle(
+            """
             |kotlin {
             |    sourceSets.main {
             |       kotlin.srcDirs("src")
@@ -267,10 +268,11 @@ internal class KtfmtCheckTaskIntegrationTest {
             |       kotlin.srcDirs("test")
             |    }
             |}
-        """.trimMargin())
+        """
+                .trimMargin())
 
-        createTempFile("val answer = 42", path = "src/someFolder")
-        createTempFile("val answer = 42", path = "test/someOtherFolder")
+        createTempFile("val answer = 42\n", path = "src/someFolder")
+        createTempFile("val answer = 42\n", path = "test/someOtherFolder")
 
         val result =
             GradleRunner.create()
@@ -290,16 +292,14 @@ internal class KtfmtCheckTaskIntegrationTest {
         }
     }
 
-
     private fun createTempFile(
         @Language("kotlin") content: String,
         fileName: String = "TestFile.kt",
         path: String = "src/main/java"
-    ): File {
-     return tempDir.resolve(path).resolve(fileName).apply {
+    ): File =
+        tempDir.resolve(path).resolve(fileName).apply {
             parentFile.mkdirs()
             createNewFile()
             writeText(content)
         }
-    }
 }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import java.io.File
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -21,8 +22,6 @@ internal class KtfmtCheckTaskIntegrationTest {
 
     @BeforeEach
     fun setUp() {
-        File(tempDir, "src/main/java").mkdirs()
-        File(tempDir, "src/test/java").mkdirs()
         File("src/test/resources/jvmProject").copyRecursively(tempDir)
     }
 
@@ -257,13 +256,50 @@ internal class KtfmtCheckTaskIntegrationTest {
         assertThat(result!!.output).contains("Reusing configuration cache.")
     }
 
+    @Test
+    fun `check task should detect the source and test files in a flattened project structure`() {
+        appendToBuildGradle("""
+            |kotlin {
+            |    sourceSets.main {
+            |       kotlin.srcDirs("src")
+            |    }
+            |    sourceSets.test {
+            |       kotlin.srcDirs("test")
+            |    }
+            |}
+        """.trimMargin())
+
+        createTempFile("val answer = 42", path = "src/someFolder")
+        createTempFile("val answer = 42", path = "test/someOtherFolder")
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(tempDir)
+                .withPluginClasspath()
+                .withArguments("ktfmtCheck")
+                .build()
+
+        assertThat(result.task(":ktfmtCheckMain")?.outcome).isNotEqualTo(TaskOutcome.NO_SOURCE)
+        assertThat(result.task(":ktfmtCheckTest")?.outcome).isNotEqualTo(TaskOutcome.NO_SOURCE)
+    }
+
+    private fun appendToBuildGradle(content: String) {
+        tempDir.resolve("build.gradle.kts").apply {
+            appendText(System.lineSeparator())
+            appendText(content)
+        }
+    }
+
+
     private fun createTempFile(
         @Language("kotlin") content: String,
         fileName: String = "TestFile.kt",
         path: String = "src/main/java"
-    ) =
-        File(File(tempDir, path), fileName).apply {
+    ): File {
+     return tempDir.resolve(path).resolve(fileName).apply {
+            parentFile.mkdirs()
             createNewFile()
             writeText(content)
         }
+    }
 }


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
Use provider to lazily evaluate the sourceSets.

See issue: https://github.com/cortinico/ktfmt-gradle/issues/292

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/cortinico/ktfmt-gradle/issues/292

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

A new integration test was added. Initially the test failed and is now green.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.