### PR TITLE
#292 Fix custom sources location not being recognized by ktfmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please add your entries according to this format.
 ## Unreleased
 
 - Fix custom KtFmt tasks not compatible with configuration cache (#290)
+- Fix custom source directories not correctly recognized (#292)
 
 ## Version 0.19.0 _(2024-07-03)_
 

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,4 +1,6 @@
+import app.cash.sqldelight.gradle.SqlDelightWorkerTask
 import app.cash.sqldelight.gradle.VerifyMigrationTask
+import com.ncorti.ktfmt.gradle.tasks.KtfmtBaseTask
 
 plugins {
     kotlin("jvm")
@@ -22,6 +24,11 @@ dependencies {
 tasks.withType<Test> { useJUnitPlatform() }
 
 tasks.withType<VerifyMigrationTask> { enabled = false }
+
+tasks.withType<KtfmtBaseTask>(){
+    mustRunAfter(tasks.withType<SqlDelightWorkerTask>())
+}
+
 
 sqldelight { databases { create("Database") { packageName.set("com.example") } } }
 

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPluginUtils.kt
@@ -77,7 +77,7 @@ internal object KtfmtPluginUtils {
                 charArray.concatToString()
             }
         val taskName = "$TASK_NAME_CHECK$capitalizedName"
-        val inputDirs = srcDir.toList()
+        val inputDirs = project.provider { srcDir.toList() }
         return project.tasks.register(taskName, KtfmtCheckTask::class.java) {
             it.description =
                 "Run Ktfmt formatter for sourceSet '$name' on project '${project.name}'"
@@ -104,7 +104,7 @@ internal object KtfmtPluginUtils {
                 charArray.concatToString()
             }
         val taskName = "$TASK_NAME_FORMAT$srcSetName"
-        val inputDirs = srcDir.toList()
+        val inputDirs = project.provider { srcDir.toList() }
         return project.tasks.register(taskName, KtfmtFormatTask::class.java) {
             it.description =
                 "Run Ktfmt formatter validation for sourceSet '$name' on project '${project.name}'"


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
As described in https://github.com/cortinico/ktfmt-gradle/issues/292 the main issue is that the SourceDirectorySet::getSourceDirectories() can change. When the ktfmt plugin is configured before the sourceDirectory is changed, the plugin will format the old directory where no sources are located.

That's why we have to evaluate it lazily. This is done in this PR.

Unfortunately, there are one side effect that I am not able to solve. 

In the example module, we get the following error when running the check task

```
A problem was found with the configuration of task ':example:generateMainDatabaseInterface' (type 'SqlDelightTask').
  - Gradle detected a problem with the following location: '/home/shauck/dev/workspace/ktfmt-gradle2/example/build/generated/sqldelight/code/Database/main'.
    
    Reason: Task ':example:ktfmtCheckMain' uses this output of task ':example:generateMainDatabaseInterface' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':example:generateMainDatabaseInterface' as an input of ':example:ktfmtCheckMain'.
      2. Declare an explicit dependency on ':example:generateMainDatabaseInterface' from ':example:ktfmtCheckMain' using Task#dependsOn.
      3. Declare an explicit dependency on ':example:generateMainDatabaseInterface' from ':example:ktfmtCheckMain' using Task#mustRunAfter.
```

The sqlDelight plugin generates a kotlin main sourceSet. So it is expected, that the dependencies between the two tasks must be explicitly configured. This is done on the example ``build.gradle.kts``.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

https://github.com/cortinico/ktfmt-gradle/issues/292

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

An integration test was added for the check and format task.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

it is in some sense a breaking change because users might have to explicitly specify the dependencies of ktfmt to other tasks that modify the sourceSets.

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.