### PR TITLE
Add `ktfmt.useClassloaderIsolation` property to toggle classloader isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Please add your entries according to this format.
 
 ## Unreleased
 
-- Add `ktfmt.useClassloaderIsolation` property to toggle between processIsolation and classloaderIsolation for the Gradle Worker
+- Add `ktfmt.useClassloaderIsolation` property to toggle between processIsolation and classloaderIsolation for the Gradle Worker (#427)
 
 ## Version 0.22.0 _(2025-02-06)_
 - Add tasks `ktfmtCheckScripts` and `ktfmtFormatScripts` to check and format the `.kts` files in the project folder. (#382)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+- Add `ktfmt.useClassloaderIsolation` property to toggle between processIsolation and classloaderIsolation for the Gradle Worker
+
 ## Version 0.22.0 _(2025-02-06)_
 - Add tasks `ktfmtCheckScripts` and `ktfmtFormatScripts` to check and format the `.kts` files in the project folder. (#382)
 - Remove transitive ktfmt dependencies from the plugin to avoid conflicts with the project dependencies. (#394, #181)

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -7,6 +7,7 @@ public abstract class com/ncorti/ktfmt/gradle/KtfmtExtension {
 	public abstract fun getMaxWidth ()Lorg/gradle/api/provider/Property;
 	public abstract fun getRemoveUnusedImports ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSrcSetPathExclusionPattern ()Lorg/gradle/api/provider/Property;
+	public abstract fun getUseClassloaderIsolation ()Lorg/gradle/api/provider/Property;
 	public final fun googleStyle ()V
 	public final fun kotlinLangStyle ()V
 }

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -25,6 +25,7 @@ public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask : org/gradle/a
 	public abstract fun getIncludeOnly ()Lorg/gradle/api/provider/Property;
 	public final fun getOutput ()Lorg/gradle/api/provider/Provider;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
+	public abstract fun getUseClassloaderIsolation ()Lorg/gradle/api/provider/Property;
 	protected abstract fun handleResultSummary (Lcom/ncorti/ktfmt/gradle/util/KtfmtResultSummary;)V
 }
 

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
@@ -13,6 +13,7 @@ abstract class KtfmtExtension {
         debuggingPrintOpsAfterFormatting.convention(DEFAULT_DEBUGGING_PRINT_OPTS)
         manageTrailingCommas.convention(DEFAULT_MANAGE_TRAILING_COMMAS)
         srcSetPathExclusionPattern.convention(DEFAULT_SRC_SET_PATH_EXCLUSION_PATTERN)
+        useClassloaderIsolation.convention(DEFAULT_USE_CLASSLOADER_ISOLATION)
     }
 
     /** ktfmt breaks lines longer than maxWidth. Default 100. */
@@ -69,6 +70,12 @@ abstract class KtfmtExtension {
      */
     abstract val debuggingPrintOpsAfterFormatting: Property<Boolean>
 
+    /**
+     * Whether the Gradle Worker should use ClassLoader isolation (true) or Process isolation
+     * (false - default).
+     */
+    abstract val useClassloaderIsolation: Property<Boolean>
+
     /** Sets the Google style (equivalent to set blockIndent to 2 and continuationIndent to 2). */
     @Suppress("MagicNumber")
     fun googleStyle() {
@@ -105,6 +112,7 @@ abstract class KtfmtExtension {
         internal const val DEFAULT_REMOVE_UNUSED_IMPORTS: Boolean = true
         internal const val DEFAULT_DEBUGGING_PRINT_OPTS: Boolean = false
         internal const val DEFAULT_MANAGE_TRAILING_COMMAS: Boolean = false
+        internal const val DEFAULT_USE_CLASSLOADER_ISOLATION: Boolean = false
         internal val DEFAULT_SRC_SET_PATH_EXCLUSION_PATTERN =
             Regex("^(.*[\\\\/])?build([\\\\/].*)?\$")
     }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
@@ -53,10 +53,7 @@ abstract class KtfmtPlugin : Plugin<Project> {
         project.tasks.withType(KtfmtBaseTask::class.java).configureEach {
             it.ktfmtClasspath.from(ktFmt)
             it.formattingOptionsBean.set(ktfmtExtension.toFormattingOptions())
-            it.useClassloaderIsolation.set(
-                project.findProperty("ktfmt.useClassloaderIsolation")?.toString()?.toBoolean() ==
-                    true
-            )
+            it.useClassloaderIsolation.set(ktfmtExtension.useClassloaderIsolation)
         }
 
         topLevelFormat = createTopLevelFormatTask(project)

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
@@ -53,6 +53,10 @@ abstract class KtfmtPlugin : Plugin<Project> {
         project.tasks.withType(KtfmtBaseTask::class.java).configureEach {
             it.ktfmtClasspath.from(ktFmt)
             it.formattingOptionsBean.set(ktfmtExtension.toFormattingOptions())
+            it.useClassloaderIsolation.set(
+                project.findProperty("ktfmt.useClassloaderIsolation")?.toString()?.toBoolean() ==
+                    true
+            )
         }
 
         topLevelFormat = createTopLevelFormatTask(project)

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
@@ -39,7 +39,6 @@ abstract class KtfmtBaseTask internal constructor(private val layout: ProjectLay
 
     init {
         includeOnly.convention("")
-        useClassloaderIsolation.convention(false)
     }
 
     @get:Classpath @get:InputFiles internal abstract val ktfmtClasspath: ConfigurableFileCollection

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
@@ -6,6 +6,7 @@ import com.ncorti.ktfmt.gradle.KtfmtExtension.Companion.DEFAULT_CONTINUATION_IND
 import com.ncorti.ktfmt.gradle.KtfmtExtension.Companion.DEFAULT_DEBUGGING_PRINT_OPTS
 import com.ncorti.ktfmt.gradle.KtfmtExtension.Companion.DEFAULT_MAX_WIDTH
 import com.ncorti.ktfmt.gradle.KtfmtExtension.Companion.DEFAULT_REMOVE_UNUSED_IMPORTS
+import com.ncorti.ktfmt.gradle.KtfmtExtension.Companion.DEFAULT_USE_CLASSLOADER_ISOLATION
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
 
@@ -45,6 +46,14 @@ class KtfmtExtensionTest {
 
         assertThat(extension.debuggingPrintOpsAfterFormatting.get())
             .isEqualTo(DEFAULT_DEBUGGING_PRINT_OPTS)
+    }
+
+    @Test
+    fun `useClassloaderIsolation has default value`() {
+        val extension = createExtension()
+
+        assertThat(extension.useClassloaderIsolation.get())
+            .isEqualTo(DEFAULT_USE_CLASSLOADER_ISOLATION)
     }
 
     @Test


### PR DESCRIPTION
## 🚀 Description
This introduces a Gradle property called `ktfmt.useClassloaderIsolation` that can be used to toggle between process and classloader isolation.

## 📄 Motivation and Context
We moved to process isolation in https://github.com/cortinico/ktfmt-gradle/pull/206
however this is making impossible to use classloader isolation at all.

That means that we can't use `ktfmt-gradle` inside the `ktfmt` repo reliably.

Practically if you do this:
1. gh repo clone facebook/ktfmt
2. ./gradlew ktfmtFormat

Your build will fail. You would have to invoke `./gradlew compileKotlin` first for your build to succeed. That's because the classloader of `ktfmt-gradle` is not isolated from the ktfmt build.

## 🧪 How Has This Been Tested?
Tested with maven local.

## 📦 Types of changes
- [x] New feature (non-breaking change which adds functionality)

## ✅ Checklist
- [x] My code follows the code style of this project.
