### PR TITLE
Support `com.android.kotlin.multiplatform.library`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 ### Gradle ###
 .gradle
 **/build/
+local.properties
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file follows [Keepachangelog](https://keepachangelog.com/) format.
 Please add your entries according to this format.
 
 ## Unreleased
+- Add support for android projects with the `com.android.kotlin.multiplatform.library` plugin (#422)
 
 - Add `ktfmt.useClassloaderIsolation` property to toggle between processIsolation and classloaderIsolation for the Gradle Worker (#427)
 - Kotlin to 2.1.21

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    alias(libs.plugins.android.kmp.library) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false

--- a/example-kmp-android/build.gradle.kts
+++ b/example-kmp-android/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.kmp.library)
+    id("com.ncorti.ktfmt.gradle")
+}
+
+kotlin {
+    jvmToolchain(17)
+    jvm()
+
+    androidLibrary {
+        namespace = "com.ncorti.example.ktfmt"
+        compileSdk = 33
+        minSdk = 33
+
+        withHostTest {}
+    }
+
+    sourceSets { commonTest { dependencies { implementation(kotlin("test")) } } }
+}
+
+ktfmt { kotlinLangStyle() }
+
+tasks.withType<Test> { useJUnitPlatform() }

--- a/example-kmp-android/src/androidHostTest/kotlin/ktfmt/AndroidSampleTest.kt
+++ b/example-kmp-android/src/androidHostTest/kotlin/ktfmt/AndroidSampleTest.kt
@@ -1,0 +1,13 @@
+package ktfmt
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AndroidSampleTest {
+
+    @Test
+    fun `an android sample test`() {
+        val theAnswer = 42
+        assertEquals(42, theAnswer)
+    }
+}

--- a/example-kmp-android/src/androidMain/kotlin/ktfmt/AndroidSample.kt
+++ b/example-kmp-android/src/androidMain/kotlin/ktfmt/AndroidSample.kt
@@ -1,0 +1,7 @@
+package ktfmt
+
+class AndroidSample {
+    fun main() {
+        println("Hello world")
+    }
+}

--- a/example-kmp-android/src/commonMain/kotlin/ktfmt/Sample.kt
+++ b/example-kmp-android/src/commonMain/kotlin/ktfmt/Sample.kt
@@ -1,0 +1,7 @@
+package ktfmt
+
+class Sample {
+    fun main() {
+        println("Hello world")
+    }
+}

--- a/example-kmp-android/src/commonTest/kotlin/ktfmt/SampleTest.kt
+++ b/example-kmp-android/src/commonTest/kotlin/ktfmt/SampleTest.kt
@@ -1,0 +1,13 @@
+package ktfmt
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SampleTest {
+
+    @Test
+    fun `a common sample test`() {
+        val theAnswer = 42
+        assertEquals(42, theAnswer)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ pluginPublish = "1.3.1"
 truth = "1.4.4"
 
 [plugins]
+android-kmp-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtPlugin.kt
@@ -92,9 +92,19 @@ abstract class KtfmtPlugin : Plugin<Project> {
     private fun applyKtfmtToMultiplatformProject(project: Project, ktfmtExtension: KtfmtExtension) {
         val extension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
         createScriptsTasks(project, project.projectDir, topLevelFormat, topLevelCheck)
+
+        // This plugin doesn't have any Android specific build types or features and the Android
+        // target is similar to all other KMP targets. Therefore we can use the regular source
+        // set to create the ktfmt tasks.
+        //
+        // Note that this plugin uses "android" in the source set name, but uses
+        // `KotlinPlatformType.jvm` instead of `KotlinPlatformType.androidJvm`.
+        val hasAndroidKmpLibraryPlugin =
+            project.plugins.hasPlugin("com.android.kotlin.multiplatform.library")
+
         extension.sourceSets.all {
             val name = "kmp ${it.name}"
-            if (it.name.startsWith("android")) {
+            if (!hasAndroidKmpLibraryPlugin && it.name.startsWith("android")) {
                 // We'll delegate Android Task Creation to the applyKtfmtToAndroidProject function
                 // below
                 return@all

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ rootProject.name = ("ktfmt-gradle")
 include(
     ":example",
     ":example-kmp",
+    ":example-kmp-android",
 )
 
 includeBuild(


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description

This new Android library plugin for Kotlin Multiplatform modules removes simplifies the setup for KMP projects. It removes many Android specific features such as multiple build types and adds more consistent naming to Gradle tasks and source sets. Therefore, when this plugin is applied, Android ktfmt tasks should be configured the same way as any other KMP target and not use the Android specific setup.

For more details see: https://developer.android.com/kotlin/multiplatform/plugin

## 📄 Motivation and Context

Fixes #422

## 🧪 How Has This Been Tested?

This was tested with the new example module.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.