### PR TITLE
Added support to ktfmt trailingCommaManagementStrategy (from v0.57+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ Please add your entries according to this format.
 
 ## Unreleased
 - Add support for android projects with the `com.android.kotlin.multiplatform.library` plugin (#422)
+- KtFmt to 0.58
 
+##  Version 0.23.0
 - Add `ktfmt.useClassloaderIsolation` property to toggle between processIsolation and classloaderIsolation for the Gradle Worker (#427)
 - Kotlin to 2.1.21
 - Gradle to 8.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please add your entries according to this format.
 ## Unreleased
 - Add support for android projects with the `com.android.kotlin.multiplatform.library` plugin (#422)
 - KtFmt to 0.58
+- Deprecated `manageTrailingCommas` in favor of new `trailingCommaManagementStrategy` property
 
 ##  Version 0.23.0
 - Add `ktfmt.useClassloaderIsolation` property to toggle between processIsolation and classloaderIsolation for the Gradle Worker (#427)

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ ktfmt {
     continuationIndent.set(8)
     // Whether ktfmt should remove imports that are not used.
     removeUnusedImports.set(false)
-    // Whether ktfmt should automatically add/remove trailing commas.
-    manageTrailingCommas.set(false)
+    // Whether ktfmt should automatically add/remove trailing commas (one of "NONE", "ONLY_ADD" or "COMPLETE").
+    trailingCommaManagementStrategy.set("NONE")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,12 +108,13 @@ ktfmt {
     maxWidth.set(80)
     // blockIndent is the indent size used when a new block is opened, in spaces.
     blockIndent.set(8)
-    // continuationIndent is the indent size used when a line is broken because it's too
+    // continuationIndent is the indent size used when a line is broken because it's too.
     continuationIndent.set(8)
     // Whether ktfmt should remove imports that are not used.
     removeUnusedImports.set(false)
-    // Whether ktfmt should automatically add/remove trailing commas (one of "NONE", "ONLY_ADD" or "COMPLETE").
-    trailingCommaManagementStrategy.set("NONE")
+    // Whether ktfmt should automatically add/remove trailing commas.
+    // This will be one of the options in the enum com.ncorti.ktfmt.gradle.TrailingCommaManagementStrategy.
+    trailingCommaManagementStrategy.set(NONE)
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ diffUtils = "4.16"
 junit = "5.13.4"
 kotlin = "2.1.21"
 ktfmt-plugin = "0.23.0"
-ktfmt = "0.57"
+ktfmt = "0.58"
 pluginPublish = "1.3.1"
 truth = "1.4.4"
 

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -3,13 +3,15 @@ public abstract class com/ncorti/ktfmt/gradle/KtfmtExtension {
 	public abstract fun getBlockIndent ()Lorg/gradle/api/provider/Property;
 	public abstract fun getContinuationIndent ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDebuggingPrintOpsAfterFormatting ()Lorg/gradle/api/provider/Property;
-	public abstract fun getManageTrailingCommas ()Lorg/gradle/api/provider/Property;
+	public final fun getManageTrailingCommas ()Z
 	public abstract fun getMaxWidth ()Lorg/gradle/api/provider/Property;
 	public abstract fun getRemoveUnusedImports ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSrcSetPathExclusionPattern ()Lorg/gradle/api/provider/Property;
+	public abstract fun getTrailingCommaManagementStrategy ()Lorg/gradle/api/provider/Property;
 	public abstract fun getUseClassloaderIsolation ()Lorg/gradle/api/provider/Property;
 	public final fun googleStyle ()V
 	public final fun kotlinLangStyle ()V
+	public final fun setManageTrailingCommas (Z)V
 }
 
 public abstract class com/ncorti/ktfmt/gradle/KtfmtPlugin : org/gradle/api/Plugin {

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -24,6 +24,14 @@ public abstract class com/ncorti/ktfmt/gradle/KtfmtPlugin : org/gradle/api/Plugi
 public final class com/ncorti/ktfmt/gradle/KtfmtPlugin$Companion {
 }
 
+public final class com/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy : java/lang/Enum {
+	public static final field COMPLETE Lcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;
+	public static final field NONE Lcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;
+	public static final field ONLY_ADD Lcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;
+	public static fun valueOf (Ljava/lang/String;)Lcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;
+	public static fun values ()[Lcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;
+}
+
 public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask : org/gradle/api/tasks/SourceTask {
 	public abstract fun getIncludeOnly ()Lorg/gradle/api/provider/Property;
 	public final fun getOutput ()Lorg/gradle/api/provider/Provider;

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
@@ -34,20 +34,9 @@ internal data class FormattingOptionsBean(
     /**
      * Strategy for managing trailing commas.
      *
-     * Options:
-     * - NONE
-     *     - Do not manage trailing commas at all, only format what is already present
-     * - ONLY_ADD
-     *     - Only add trailing commas when necessary, but do not remove them.
-     *     - Lists that cannot fit on one line will have trailing commas inserted. Trailing commas
-     *       can to be used to "hint" ktfmt that the list should be broken to multiple lines.
-     * - COMPLETE
-     *     - Fully manage trailing commas, adding and removing them where necessary.
-     *     - Lists that cannot fit on one line will have trailing commas inserted. Lists that span
-     *       multiple lines will have them removed. Manually inserted trailing commas cannot be used
-     *       as a hint to force breaking lists to multiple lines.
+     * See [TrailingCommaManagementStrategy] for more details.
      */
-    val trailingCommaManagementStrategy: String,
+    val trailingCommaManagementStrategy: TrailingCommaManagementStrategy,
 
     /** Whether ktfmt should remove imports that are not used. */
     val removeUnusedImports: Boolean = true,

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
@@ -32,13 +32,22 @@ internal data class FormattingOptionsBean(
     val continuationIndent: Int = 4,
 
     /**
-     * Automatically remove and insert trialing commas.
+     * Strategy for managing trailing commas.
      *
-     * Lists that cannot fit on one line will have trailing commas inserted. Lists that span
-     * multiple lines will have them removed. Manually inserted trailing commas cannot be used as a
-     * hint to force breaking lists to multiple lines.
+     * Options:
+     * - NONE
+     *     - Do not manage trailing commas at all, only format what is already present
+     * - ONLY_ADD
+     *     - Only add trailing commas when necessary, but do not remove them.
+     *     - Lists that cannot fit on one line will have trailing commas inserted. Trailing commas
+     *       can to be used to "hint" ktfmt that the list should be broken to multiple lines.
+     * - COMPLETE
+     *     - Fully manage trailing commas, adding and removing them where necessary.
+     *     - Lists that cannot fit on one line will have trailing commas inserted. Lists that span
+     *       multiple lines will have them removed. Manually inserted trailing commas cannot be used
+     *       as a hint to force breaking lists to multiple lines.
      */
-    val manageTrailingCommas: Boolean = false,
+    val trailingCommaManagementStrategy: String,
 
     /** Whether ktfmt should remove imports that are not used. */
     val removeUnusedImports: Boolean = true,

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
@@ -46,20 +46,9 @@ abstract class KtfmtExtension {
     /**
      * Strategy for managing trailing commas.
      *
-     * Options:
-     * - NONE
-     *     - Do not manage trailing commas at all, only format what is already present
-     * - ONLY_ADD
-     *     - Only add trailing commas when necessary, but do not remove them.
-     *     - Lists that cannot fit on one line will have trailing commas inserted. Trailing commas
-     *       can to be used to "hint" ktfmt that the list should be broken to multiple lines.
-     * - COMPLETE
-     *     - Fully manage trailing commas, adding and removing them where necessary.
-     *     - Lists that cannot fit on one line will have trailing commas inserted. Lists that span
-     *       multiple lines will have them removed. Manually inserted trailing commas cannot be used
-     *       as a hint to force breaking lists to multiple lines.
+     * See [TrailingCommaManagementStrategy] for more details.
      */
-    abstract val trailingCommaManagementStrategy: Property<String>
+    abstract val trailingCommaManagementStrategy: Property<TrailingCommaManagementStrategy>
 
     /** Whether ktfmt should remove imports that are not used. */
     abstract val removeUnusedImports: Property<Boolean>
@@ -91,16 +80,19 @@ abstract class KtfmtExtension {
     )
     var manageTrailingCommas: Boolean
         set(value) {
-            trailingCommaManagementStrategy.set(if (value) "COMPLETE" else "NONE")
+            trailingCommaManagementStrategy.set(
+                if (value) TrailingCommaManagementStrategy.COMPLETE
+                else TrailingCommaManagementStrategy.NONE
+            )
         }
-        get() = trailingCommaManagementStrategy.get().uppercase() != "NONE"
+        get() = trailingCommaManagementStrategy.get() != TrailingCommaManagementStrategy.NONE
 
     /** Sets the Google style (equivalent to set blockIndent to 2 and continuationIndent to 2). */
     @Suppress("MagicNumber")
     fun googleStyle() {
         blockIndent.set(2)
         continuationIndent.set(2)
-        trailingCommaManagementStrategy.set("COMPLETE")
+        trailingCommaManagementStrategy.set(TrailingCommaManagementStrategy.COMPLETE)
     }
 
     /**
@@ -111,7 +103,7 @@ abstract class KtfmtExtension {
     fun kotlinLangStyle() {
         blockIndent.set(4)
         continuationIndent.set(4)
-        trailingCommaManagementStrategy.set("COMPLETE")
+        trailingCommaManagementStrategy.set(TrailingCommaManagementStrategy.COMPLETE)
     }
 
     internal fun toFormattingOptions(): FormattingOptionsBean =
@@ -130,7 +122,8 @@ abstract class KtfmtExtension {
         internal const val DEFAULT_CONTINUATION_INDENT: Int = 4
         internal const val DEFAULT_REMOVE_UNUSED_IMPORTS: Boolean = true
         internal const val DEFAULT_DEBUGGING_PRINT_OPTS: Boolean = false
-        internal const val DEFAULT_TRAILING_COMMAS_STRATEGY: String = "NONE"
+        internal val DEFAULT_TRAILING_COMMAS_STRATEGY: TrailingCommaManagementStrategy =
+            TrailingCommaManagementStrategy.NONE
         internal const val DEFAULT_USE_CLASSLOADER_ISOLATION: Boolean = false
         internal val DEFAULT_SRC_SET_PATH_EXCLUSION_PATTERN =
             Regex("^(.*[\\\\/])?build([\\\\/].*)?\$")

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/KtfmtExtension.kt
@@ -93,7 +93,7 @@ abstract class KtfmtExtension {
         set(value) {
             trailingCommaManagementStrategy.set(if (value) "COMPLETE" else "NONE")
         }
-        get() = trailingCommaManagementStrategy.get().uppercase() != "COMPLETE"
+        get() = trailingCommaManagementStrategy.get().uppercase() != "NONE"
 
     /** Sets the Google style (equivalent to set blockIndent to 2 and continuationIndent to 2). */
     @Suppress("MagicNumber")

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy.kt
@@ -1,0 +1,21 @@
+package com.ncorti.ktfmt.gradle
+
+enum class TrailingCommaManagementStrategy {
+    /** Do not manage trailing commas at all, only format what is already present */
+    NONE,
+    /**
+     * Only add trailing commas when necessary, but do not remove them.
+     *
+     * Lists that cannot fit on one line will have trailing commas inserted. Trailing commas can to
+     * be used to "hint" ktfmt that the list should be broken to multiple lines.
+     */
+    ONLY_ADD,
+    /**
+     * Fully manage trailing commas, adding and removing them where necessary.
+     *
+     * Lists that cannot fit on one line will have trailing commas inserted. Lists that span
+     * multiple lines will have them removed. Manually inserted trailing commas cannot be used as a
+     * hint to force breaking lists to multiple lines.
+     */
+    COMPLETE,
+}

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/worker/KtfmtWorkAction.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/worker/KtfmtWorkAction.kt
@@ -4,6 +4,7 @@ import com.facebook.ktfmt.format.Formatter
 import com.facebook.ktfmt.format.FormattingOptions
 import com.facebook.ktfmt.format.TrailingCommaManagementStrategy
 import com.ncorti.ktfmt.gradle.FormattingOptionsBean
+import com.ncorti.ktfmt.gradle.TrailingCommaManagementStrategy as TrailingCommaStrategyBean
 import com.ncorti.ktfmt.gradle.tasks.worker.KtfmtFormatResult.KtfmtFormatFailure
 import com.ncorti.ktfmt.gradle.tasks.worker.KtfmtFormatResult.KtfmtFormatSkipped
 import com.ncorti.ktfmt.gradle.tasks.worker.KtfmtFormatResult.KtfmtFormatSuccess
@@ -116,21 +117,11 @@ internal abstract class KtfmtWorkAction : WorkAction<KtfmtWorkAction.KtfmtWorkPa
             debuggingPrintOpsAfterFormatting = debuggingPrintOpsAfterFormatting,
         )
 
-    private fun String.toTrailingCommaManagementStrategy(): TrailingCommaManagementStrategy =
-        when (uppercase()) {
-            "NONE" -> TrailingCommaManagementStrategy.NONE
-            "ONLY_ADD" -> TrailingCommaManagementStrategy.ONLY_ADD
-            "COMPLETE" -> TrailingCommaManagementStrategy.COMPLETE
-            else ->
-                throw IllegalArgumentException(
-                    """
-                    Unknown trailing comma management strategy: '$this'.
-                    Must be one of 
-                    """
-                        .trimIndent() +
-                        TrailingCommaManagementStrategy.values().joinToString(", ") {
-                            "'${it.name}'"
-                        }
-                )
+    private fun TrailingCommaStrategyBean.toTrailingCommaManagementStrategy():
+        TrailingCommaManagementStrategy =
+        when (this) {
+            TrailingCommaStrategyBean.NONE -> TrailingCommaManagementStrategy.NONE
+            TrailingCommaStrategyBean.ONLY_ADD -> TrailingCommaManagementStrategy.ONLY_ADD
+            TrailingCommaStrategyBean.COMPLETE -> TrailingCommaManagementStrategy.COMPLETE
         }
 }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/worker/KtfmtWorkAction.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/worker/KtfmtWorkAction.kt
@@ -2,6 +2,7 @@ package com.ncorti.ktfmt.gradle.tasks.worker
 
 import com.facebook.ktfmt.format.Formatter
 import com.facebook.ktfmt.format.FormattingOptions
+import com.facebook.ktfmt.format.TrailingCommaManagementStrategy
 import com.ncorti.ktfmt.gradle.FormattingOptionsBean
 import com.ncorti.ktfmt.gradle.tasks.worker.KtfmtFormatResult.KtfmtFormatFailure
 import com.ncorti.ktfmt.gradle.tasks.worker.KtfmtFormatResult.KtfmtFormatSkipped
@@ -109,8 +110,27 @@ internal abstract class KtfmtWorkAction : WorkAction<KtfmtWorkAction.KtfmtWorkPa
             maxWidth = maxWidth,
             blockIndent = blockIndent,
             continuationIndent = continuationIndent,
+            trailingCommaManagementStrategy =
+                trailingCommaManagementStrategy.toTrailingCommaManagementStrategy(),
             removeUnusedImports = removeUnusedImports,
-            manageTrailingCommas = manageTrailingCommas,
             debuggingPrintOpsAfterFormatting = debuggingPrintOpsAfterFormatting,
         )
+
+    private fun String.toTrailingCommaManagementStrategy(): TrailingCommaManagementStrategy =
+        when (uppercase()) {
+            "NONE" -> TrailingCommaManagementStrategy.NONE
+            "ONLY_ADD" -> TrailingCommaManagementStrategy.ONLY_ADD
+            "COMPLETE" -> TrailingCommaManagementStrategy.COMPLETE
+            else ->
+                throw IllegalArgumentException(
+                    """
+                    Unknown trailing comma management strategy: '$this'.
+                    Must be one of 
+                    """
+                        .trimIndent() +
+                        TrailingCommaManagementStrategy.values().joinToString(", ") {
+                            "'${it.name}'"
+                        }
+                )
+        }
 }

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
@@ -84,7 +84,7 @@ class KtfmtExtensionTest {
         extension.blockIndent.set(43)
         extension.continuationIndent.set(44)
         extension.removeUnusedImports.set(false)
-        extension.trailingCommaManagementStrategy.set("COMPLETE")
+        extension.trailingCommaManagementStrategy.set(TrailingCommaManagementStrategy.COMPLETE)
         extension.debuggingPrintOpsAfterFormatting.set(true)
 
         val bean = extension.toFormattingOptions()
@@ -93,7 +93,8 @@ class KtfmtExtensionTest {
         assertThat(bean.blockIndent).isEqualTo(43)
         assertThat(bean.continuationIndent).isEqualTo(44)
         assertThat(bean.removeUnusedImports).isEqualTo(false)
-        assertThat(bean.trailingCommaManagementStrategy).isEqualTo("COMPLETE")
+        assertThat(bean.trailingCommaManagementStrategy)
+            .isEqualTo(TrailingCommaManagementStrategy.COMPLETE)
         assertThat(bean.debuggingPrintOpsAfterFormatting).isEqualTo(true)
     }
 

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/KtfmtExtensionTest.kt
@@ -84,7 +84,7 @@ class KtfmtExtensionTest {
         extension.blockIndent.set(43)
         extension.continuationIndent.set(44)
         extension.removeUnusedImports.set(false)
-        extension.manageTrailingCommas.set(true)
+        extension.trailingCommaManagementStrategy.set("COMPLETE")
         extension.debuggingPrintOpsAfterFormatting.set(true)
 
         val bean = extension.toFormattingOptions()
@@ -93,7 +93,7 @@ class KtfmtExtensionTest {
         assertThat(bean.blockIndent).isEqualTo(43)
         assertThat(bean.continuationIndent).isEqualTo(44)
         assertThat(bean.removeUnusedImports).isEqualTo(false)
-        assertThat(bean.manageTrailingCommas).isEqualTo(true)
+        assertThat(bean.trailingCommaManagementStrategy).isEqualTo("COMPLETE")
         assertThat(bean.debuggingPrintOpsAfterFormatting).isEqualTo(true)
     }
 


### PR DESCRIPTION
## 🚀 Description
Added support to ktfmt `trailingCommaManagementStrategy` property (from v0.57+)

## 🧪 How Has This Been Tested?
```
cd plugin-build
./gradlew build test
```

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.