### PR TITLE
Report failed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file follows [Keepachangelog](https://keepachangelog.com/) format.
 Please add your entries according to this format.
 
 ## Unreleased
+- Print the paths of files ktfmt failed to analyze instead of only how many files failed to be analyzed (#469) 
 
 ## Version 0.24.0 _(2025-09-08)_
 - Add support for android projects with the `com.android.kotlin.multiplatform.library` plugin (#422)

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
@@ -82,6 +82,7 @@ public abstract class KtfmtBaseTask internal constructor(private val layout: Pro
 
             val results = collectResults(tmpResultDirectory)
 
+            reportFailedFiles(results)
             handleResultSummary(results)
             writeResultsSummaryToOutput(results)
         } finally {
@@ -138,6 +139,17 @@ public abstract class KtfmtBaseTask internal constructor(private val layout: Pro
         val failedFiles = results.filter { it is KtfmtFormatFailure }.files()
 
         return KtfmtResultSummary(correctFiles, incorrectFiles, skippedFiles, failedFiles)
+    }
+
+    private fun reportFailedFiles(resultSummary: KtfmtResultSummary) {
+        if (resultSummary.failedFiles.isNotEmpty()) {
+            val fileList =
+                resultSummary.failedFiles.joinToString("\n") {
+                    it.relativeTo(layout.projectDirectory.asFile).path
+                }
+
+            error("Ktfmt failed to run with ${resultSummary.failedFiles.size} failures:\n$fileList")
+        }
     }
 
     private fun writeResultsSummaryToOutput(results: KtfmtResultSummary) =

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
@@ -20,10 +20,6 @@ internal constructor(private val layout: ProjectLayout) : KtfmtBaseTask(layout) 
     override val reformatFiles: Boolean = false
 
     override fun handleResultSummary(resultSummary: KtfmtResultSummary) {
-        if (resultSummary.failedFiles.isNotEmpty()) {
-            error("Ktfmt failed to run with ${resultSummary.failedFiles.size} failures")
-        }
-
         if (resultSummary.invalidFormattedFiles.isNotEmpty()) {
             val fileList =
                 resultSummary.invalidFormattedFiles.joinToString("\n") {

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
@@ -17,10 +17,6 @@ public abstract class KtfmtFormatTask @Inject internal constructor(layout: Proje
     override val reformatFiles: Boolean = true
 
     override fun handleResultSummary(resultSummary: KtfmtResultSummary) {
-        if (resultSummary.failedFiles.isNotEmpty()) {
-            error("Ktfmt failed to run with ${resultSummary.failedFiles.size} failures")
-        }
-
         if (resultSummary.invalidFormattedFiles.isNotEmpty()) {
             val countInvalidFiles = resultSummary.invalidFormattedFiles.size
             logger.i("Successfully reformatted $countInvalidFiles files with Ktfmt")

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTaskIntegrationTest.kt
@@ -76,6 +76,8 @@ internal class KtfmtCheckTaskIntegrationTest {
         assertThat(result.task(":ktfmtCheckMain")?.outcome).isEqualTo(FAILED)
         assertThat(result.output).containsMatch("Failed to format file: .*TestFile.kt \\(reason =")
         assertThat(result.output).contains("Ktfmt failed to run with 1 failures")
+        assertThat(result.output)
+            .contains("src${File.separator}main${File.separator}java${File.separator}TestFile.kt")
     }
 
     @Test

--- a/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
+++ b/plugin-build/plugin/src/test/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTaskIntegrationTest.kt
@@ -36,6 +36,9 @@ internal class KtfmtFormatTaskIntegrationTest {
 
         assertThat(result.task(":ktfmtFormatMain")?.outcome).isEqualTo(FAILED)
         assertThat(result.output).containsMatch("Failed to format file: .*TestFile.kt \\(reason =")
+        assertThat(result.output).contains("Ktfmt failed to run with 1 failures")
+        assertThat(result.output)
+            .contains("src${File.separator}main${File.separator}java${File.separator}TestFile.kt")
     }
 
     @Test


### PR DESCRIPTION
Until now the ktfmt Gradle plugin only reported how many files could not by analyzed by ktfmt due to a failure, but not which files. With this change failed files are printed in the log. This helps to diagnose issues.
