### PR TITLE
Make Gradle tasks reusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please add your entries according to this format.
 
 ## Unreleased
 - Print the paths of files ktfmt failed to analyze instead of only how many files failed to be analyzed (#469) 
+- Make Gradle tasks `KtfmtBaseTask`, `KtfmtCheckTask` and `KtfmtFormatTask` reusable from other Gradle plugins (#467)
 
 ## Version 0.24.0 _(2025-09-08)_
 - Add support for android projects with the `com.android.kotlin.multiplatform.library` plugin (#422)

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -1,3 +1,27 @@
+public final class com/ncorti/ktfmt/gradle/FormattingOptionsBean : java/io/Serializable {
+	public static final field defaultMaxWidth I
+	public static final field serialVersionUID J
+	public fun <init> (IIILcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;ZZ)V
+	public synthetic fun <init> (IIILcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Lcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun copy (IIILcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;ZZ)Lcom/ncorti/ktfmt/gradle/FormattingOptionsBean;
+	public static synthetic fun copy$default (Lcom/ncorti/ktfmt/gradle/FormattingOptionsBean;IIILcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;ZZILjava/lang/Object;)Lcom/ncorti/ktfmt/gradle/FormattingOptionsBean;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlockIndent ()I
+	public final fun getContinuationIndent ()I
+	public final fun getDebuggingPrintOpsAfterFormatting ()Z
+	public final fun getMaxWidth ()I
+	public final fun getRemoveUnusedImports ()Z
+	public final fun getTrailingCommaManagementStrategy ()Lcom/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class com/ncorti/ktfmt/gradle/KtfmtExtension {
 	public fun <init> ()V
 	public abstract fun getBlockIndent ()Lorg/gradle/api/provider/Property;
@@ -29,18 +53,26 @@ public final class com/ncorti/ktfmt/gradle/TrailingCommaManagementStrategy : jav
 }
 
 public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask : org/gradle/api/tasks/SourceTask {
+	public fun <init> (Lorg/gradle/api/file/ProjectLayout;)V
+	public abstract fun getFormattingOptionsBean ()Lorg/gradle/api/provider/Property;
 	public abstract fun getIncludeOnly ()Lorg/gradle/api/provider/Property;
+	public abstract fun getKtfmtClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getOutput ()Lorg/gradle/api/provider/Provider;
+	public abstract fun getReformatFiles ()Z
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
 	public abstract fun getUseClassloaderIsolation ()Lorg/gradle/api/provider/Property;
 	protected abstract fun handleResultSummary (Lcom/ncorti/ktfmt/gradle/util/KtfmtResultSummary;)V
 }
 
 public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask : com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask {
+	public fun <init> (Lorg/gradle/api/file/ProjectLayout;)V
+	public final fun getReformatFiles ()Z
 	protected fun handleResultSummary (Lcom/ncorti/ktfmt/gradle/util/KtfmtResultSummary;)V
 }
 
 public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask : com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask {
+	public fun <init> (Lorg/gradle/api/file/ProjectLayout;)V
+	public final fun getReformatFiles ()Z
 	protected fun handleResultSummary (Lcom/ncorti/ktfmt/gradle/util/KtfmtResultSummary;)V
 }
 

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/FormattingOptionsBean.kt
@@ -2,7 +2,7 @@ package com.ncorti.ktfmt.gradle
 
 import java.io.Serializable
 
-internal data class FormattingOptionsBean(
+public data class FormattingOptionsBean(
 
     /** ktfmt breaks lines longer than maxWidth. */
     val maxWidth: Int = defaultMaxWidth,
@@ -48,8 +48,8 @@ internal data class FormattingOptionsBean(
     val debuggingPrintOpsAfterFormatting: Boolean = false,
 ) : Serializable {
 
-    companion object {
-        private const val serialVersionUID: Long = 1L
-        private const val defaultMaxWidth = 100
+    private companion object {
+        const val serialVersionUID: Long = 1L
+        const val defaultMaxWidth = 100
     }
 }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
@@ -34,16 +34,15 @@ import org.gradle.workers.WorkerExecutor
 
 /** ktfmt-gradle base Gradle tasks. Contains methods to properly process a single file with ktfmt */
 @Suppress("LeakingThis")
-public abstract class KtfmtBaseTask internal constructor(private val layout: ProjectLayout) :
-    SourceTask() {
+public abstract class KtfmtBaseTask(private val layout: ProjectLayout) : SourceTask() {
 
     init {
         includeOnly.convention("")
     }
 
-    @get:Classpath @get:InputFiles internal abstract val ktfmtClasspath: ConfigurableFileCollection
+    @get:Classpath @get:InputFiles public abstract val ktfmtClasspath: ConfigurableFileCollection
 
-    @get:Input internal abstract val formattingOptionsBean: Property<FormattingOptionsBean>
+    @get:Input public abstract val formattingOptionsBean: Property<FormattingOptionsBean>
 
     @get:Option(
         option = "include-only",
@@ -68,8 +67,11 @@ public abstract class KtfmtBaseTask internal constructor(private val layout: Pro
 
     @get:Inject internal abstract val workerExecutor: WorkerExecutor
 
-    @get:Internal internal abstract val reformatFiles: Boolean
+    @get:Internal public abstract val reformatFiles: Boolean
 
+    /**
+     * Called after all files have been analyzed and [resultSummary] has been written into [output].
+     */
     protected abstract fun handleResultSummary(resultSummary: KtfmtResultSummary)
 
     @TaskAction
@@ -83,8 +85,8 @@ public abstract class KtfmtBaseTask internal constructor(private val layout: Pro
             val results = collectResults(tmpResultDirectory)
 
             reportFailedFiles(results)
-            handleResultSummary(results)
             writeResultsSummaryToOutput(results)
+            handleResultSummary(results)
         } finally {
             tmpResultDirectory.deleteRecursively()
         }

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtCheckTask.kt
@@ -9,15 +9,14 @@ import org.gradle.api.tasks.CacheableTask
 
 /** ktfmt-gradle Check task. Verifies if the output of ktfmt is the same as the input */
 @CacheableTask
-public abstract class KtfmtCheckTask
-@Inject
-internal constructor(private val layout: ProjectLayout) : KtfmtBaseTask(layout) {
+public abstract class KtfmtCheckTask @Inject public constructor(private val layout: ProjectLayout) :
+    KtfmtBaseTask(layout) {
 
     init {
         group = KtfmtUtils.GROUP_VERIFICATION
     }
 
-    override val reformatFiles: Boolean = false
+    final override val reformatFiles: Boolean = false
 
     override fun handleResultSummary(resultSummary: KtfmtResultSummary) {
         if (resultSummary.invalidFormattedFiles.isNotEmpty()) {

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtFormatTask.kt
@@ -7,14 +7,14 @@ import javax.inject.Inject
 import org.gradle.api.file.ProjectLayout
 
 /** ktfmt-gradle Format task. Replaces input file content with its formatted equivalent. */
-public abstract class KtfmtFormatTask @Inject internal constructor(layout: ProjectLayout) :
+public abstract class KtfmtFormatTask @Inject public constructor(layout: ProjectLayout) :
     KtfmtBaseTask(layout) {
 
     init {
         group = KtfmtUtils.GROUP_FORMATTING
     }
 
-    override val reformatFiles: Boolean = true
+    final override val reformatFiles: Boolean = true
 
     override fun handleResultSummary(resultSummary: KtfmtResultSummary) {
         if (resultSummary.invalidFormattedFiles.isNotEmpty()) {


### PR DESCRIPTION


With this change `KtfmtBaseTask`, `KtfmtCheckTask` and `KtfmtFormatTask` become extensible and reusable from other Gradle plugins. The use case is for projects that cannot use the default wiring of this Gradle plugin.

Fixes #467