### PR TITLE
Prepare Release 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ This file follows [Keepachangelog](https://keepachangelog.com/) format.
 Please add your entries according to this format.
 
 ## Unreleased
-- Bump Kotlin language/api version to 2.0 to support Kotlin 2.3.20+ (#472)
-- Annotate `KtfmtBaseTask` and `KtfmtFormatTask` with `@DisableCachingByDefault` for Gradle 9.4.0 compatibility (#474)
+
+## Version 0.26.0 _(2026-03-18)_
 - Use lazy configuration APIs to improve Gradle's configuration caching (#478)
 - Fix the default (Meta) style to match the default style of ktfmt itself (#480)
 - Fix `ktfmtFormat` task incorrectly skipping execution when files are reverted to an unformatted state (#485)
 - Ensure `ktfmtCheckScripts` and `ktfmtFormatScripts` are correctly registered even in projects without Kotlin plugins (#486)
+- Kotlin to 2.3.20
+- Gradle to 9.4.0
+- AGP to 8.13.2
+- KtFmt to 0.62
 
 ## Version 0.25.0 _(2025-10-23)_
 - Print the paths of files ktfmt failed to analyze instead of only how many files failed to be analyzed (#470) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Please add your entries according to this format.
 ## Unreleased
 
 ## Version 0.26.0 _(2026-03-18)_
+- Bump Kotlin language/api version to 2.0 to support Kotlin 2.3.20+ (#472)
+- Annotate `KtfmtBaseTask` and `KtfmtFormatTask` with `@DisableCachingByDefault` for Gradle 9.4.0 compatibility (#474)
 - Use lazy configuration APIs to improve Gradle's configuration caching (#478)
 - Fix the default (Meta) style to match the default style of ktfmt itself (#480)
 - Fix `ktfmtFormat` task incorrectly skipping execution when files are reverted to an unformatted state (#485)

--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -1,5 +1,5 @@
 ID=com.ncorti.ktfmt.gradle
-VERSION=0.25.0
+VERSION=0.26.0
 GROUP=com.ncorti.ktfmt.gradle
 DISPLAY_NAME=ktfmt-gradle
 DESCRIPTION=A Gradle plugin to run ktfmt formatter on your build


### PR DESCRIPTION
## Summary

- Bumps version to `0.26.0` in `plugin-build/gradle.properties`
- Updates `CHANGELOG.md` with the `0.26.0` release entry

## What's in this release

- Use lazy configuration APIs to improve Gradle's configuration caching (#478)
- Fix the default (Meta) style to match the default style of ktfmt itself (#480)
- Fix `ktfmtFormat` task incorrectly skipping execution when files are reverted to an unformatted state (#485)
- Ensure `ktfmtCheckScripts` and `ktfmtFormatScripts` are correctly registered even in projects without Kotlin plugins (#486)
- Kotlin to 2.3.20
- Gradle to 9.4.0
- AGP to 8.13.2
- KtFmt to 0.62

## Test plan

- [ ] CI passes on this PR
- [ ] Review CHANGELOG entry and version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)