### PR TITLE
Add support for configuring JVM arguments in process isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file follows [Keepachangelog](https://keepachangelog.com/) format.
 Please add your entries according to this format.
 
 ## Unreleased
+- Add support for configuring JVM arguments in process isolation (#509)
 
 ## Version 0.26.0 _(2026-03-18)_
 - Bump Kotlin language/api version to 2.0 to support Kotlin 2.3.20+ (#472)

--- a/plugin-build/plugin/api/plugin.api
+++ b/plugin-build/plugin/api/plugin.api
@@ -60,6 +60,7 @@ public abstract class com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask : org/gradle/a
 	public abstract fun getIncludeOnly ()Lorg/gradle/api/provider/Property;
 	public abstract fun getKtfmtClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getOutput ()Lorg/gradle/api/provider/Provider;
+	public abstract fun getProcessIsolationJvmArgs ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getReformatFiles ()Z
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
 	public abstract fun getUseClassloaderIsolation ()Lorg/gradle/api/provider/Property;

--- a/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/ktfmt/gradle/tasks/KtfmtBaseTask.kt
@@ -16,6 +16,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Classpath
@@ -55,6 +56,8 @@ public abstract class KtfmtBaseTask(private val layout: ProjectLayout) : SourceT
     public abstract val includeOnly: Property<String>
 
     @get:Input public abstract val useClassloaderIsolation: Property<Boolean>
+
+    @get:Input public abstract val processIsolationJvmArgs: ListProperty<String>
 
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
@@ -100,7 +103,10 @@ public abstract class KtfmtBaseTask(private val layout: ProjectLayout) : SourceT
             if (useClassloaderIsolation.get()) {
                 workerExecutor.classLoaderIsolation { it.classpath.from(ktfmtClasspath) }
             } else {
-                workerExecutor.processIsolation { it.classpath.from(ktfmtClasspath) }
+                workerExecutor.processIsolation { workerSpec ->
+                    workerSpec.classpath.from(ktfmtClasspath)
+                    workerSpec.forkOptions { it.jvmArgs(processIsolationJvmArgs.get()) }
+                }
             }
 
         val includedFiles = getIncludedFiles()


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->

Simply adds a `processIsolationJvmArgs` string list property and appropriately configures the process isolation worker.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

To allow users to pass JVM args to the process isolation worker. Closes #508 .

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This has been tested by forcing a JDK 24 toolchain and add the following configuration in `example`, `example-kmp` and `example-kmp-android`. (This has not been committed in this PR.)

```kotlin
tasks.withType<KtfmtBaseTask> {
    processIsolationJvmArgs.addAll("--sun-misc-unsafe-memory-access=allow")
}
```

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.