### PR TITLE
Declare Configuration Cache compatibility

### DIFF
--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.plugin.compatibility.compatibility
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
@@ -77,6 +78,8 @@ gradlePlugin {
             displayName = property("DISPLAY_NAME").toString()
             description = property("DESCRIPTION").toString()
             tags = listOf("ktfmt", "kotlin", "formatter", "reformat", "style", "code", "linter")
+
+            compatibility { features { configurationCache = true } }
         }
     }
 


### PR DESCRIPTION
## 🚀 Description
Declare Configuration Cache compatibility in the plugin metadata

## 📄 Motivation and Context
Helps users to choose Configuration Cache compatible plugins

## 🧪 How Has This Been Tested?
Built the plugin locally and verified that the metadata file contains CC support property:
```
implementation-class=com.ncorti.ktfmt.gradle.KtfmtPlugin
compatibility.feature.configuration-cache=DECLARED_SUPPORTED
```

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.