### PR TITLE
Replace usages of deprecated Kotlin DSL delegates

### DIFF
--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
  * dependencies into TestKit plugin classpath via [PluginUnderTestMetadata] to make them available
  * for testing.
  */
-val integrationTestRuntime: Configuration by configurations.creating
+val integrationTestRuntime = configurations.create("integrationTestRuntime")
 
 integrationTestRuntime.apply {
     extendsFrom(configurations.getByName("compileOnly"))
@@ -92,11 +92,12 @@ signing {
 
 tasks.withType<Test> { useJUnitPlatform() }
 
-val persistKtfmtVersion by tasks.registering {
-    inputs.property("ktfmtVersion", libs.ktfmt)
-    outputs.files(layout.buildDirectory.file("ktfmt-version.txt"))
-    doLast { outputs.files.singleFile.writeText(inputs.properties["ktfmtVersion"].toString()) }
-}
+val persistKtfmtVersion =
+    tasks.register("persistKtfmtVersion") {
+        inputs.property("ktfmtVersion", libs.ktfmt)
+        outputs.files(layout.buildDirectory.file("ktfmt-version.txt"))
+        doLast { outputs.files.singleFile.writeText(inputs.properties["ktfmtVersion"].toString()) }
+    }
 
 tasks.named<ProcessResources>("processResources") {
     from(persistKtfmtVersion) { into("com/ncorti/ktfmt/gradle") }


### PR DESCRIPTION
## 🚀 Description
Replace usages of deprecated Kotlin DSL delegates with direct assignments

## 📄 Motivation and Context
Kotlin DSL delegates are deprecated and scheduled to be removed in Gradle 10.
See https://github.com/gradle/gradle/issues/37555

## 🧪 How Has This Been Tested?
Verified by running the affected Gradle tasks manually

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.